### PR TITLE
Use JSON-RPC transport

### DIFF
--- a/src/Transport/JsonRpc/JsonRpcClientInterface.php
+++ b/src/Transport/JsonRpc/JsonRpcClientInterface.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the playwright-php/playwright package.
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace PlaywrightPHP\Transport\JsonRpc;
+
+/**
+ * Interface for JSON-RPC client implementations.
+ *
+ * @experimental
+ *
+ * @author Simon André <smn.andre@gmail.com>
+ */
+interface JsonRpcClientInterface
+{
+    /**
+     * Send a JSON-RPC request and wait for response.
+     *
+     * @param array<string, mixed>|null $params
+     *
+     * @return array<string, mixed>
+     */
+    public function send(string $method, ?array $params = null, ?float $timeoutMs = null): array;
+
+    /**
+     * Send a raw message in the original format and wait for response.
+     *
+     * @param array<string, mixed> $message
+     *
+     * @return array<string, mixed>
+     */
+    public function sendRaw(array $message, ?float $timeoutMs = null): array;
+
+    /**
+     * @return array<int, array{method: string, timestamp: float, age: float}>
+     */
+    public function getPendingRequests(): array;
+
+    public function cancelPendingRequests(): void;
+}

--- a/src/Transport/JsonRpc/JsonRpcTransport.php
+++ b/src/Transport/JsonRpc/JsonRpcTransport.php
@@ -103,15 +103,17 @@ final class JsonRpcTransport implements TransportInterface
         $this->ensureConnected();
 
         try {
-            $method = $message['action'] ?? 'unknown';
-            $params = $this->extractParams($message);
+            // Send the message in the original format, not JSON-RPC format
+            // The LSP framing handles the transport protocol, but the message content
+            // remains compatible with the existing Node.js server
             $timeout = $this->config['timeout'] ?? null;
+            $timeoutMs = $timeout ? $timeout * 1000 : null;
 
-            return $this->client->send($method, $params, $timeout ? $timeout * 1000 : null);
+            return $this->client->sendRaw($message, $timeoutMs);
         } catch (\Throwable $e) {
             $this->logger->error('JSON-RPC send failed', [
                 'error' => $e->getMessage(),
-                'method' => $message['action'] ?? 'unknown',
+                'action' => $message['action'] ?? 'unknown',
             ]);
             throw $e;
         }

--- a/src/Transport/JsonRpc/ProcessLauncherInterface.php
+++ b/src/Transport/JsonRpc/ProcessLauncherInterface.php
@@ -12,6 +12,7 @@ namespace PlaywrightPHP\Transport\JsonRpc;
 
 use PlaywrightPHP\Exception\ProcessCrashedException;
 use PlaywrightPHP\Exception\ProcessLaunchException;
+use Symfony\Component\Process\InputStream;
 use Symfony\Component\Process\Process;
 
 /**
@@ -51,4 +52,6 @@ interface ProcessLauncherInterface
      * @throws ProcessCrashedException
      */
     public function waitForExit(Process $process, ?float $timeoutSeconds = null): int;
+
+    public function getInputStream(): ?InputStream;
 }

--- a/src/Transport/TransportFactory.php
+++ b/src/Transport/TransportFactory.php
@@ -12,6 +12,8 @@ namespace PlaywrightPHP\Transport;
 
 use PlaywrightPHP\Configuration\PlaywrightConfig;
 use PlaywrightPHP\Node\NodeBinaryResolver;
+use PlaywrightPHP\Transport\JsonRpc\JsonRpcTransport;
+use PlaywrightPHP\Transport\JsonRpc\ProcessLauncher;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -31,14 +33,17 @@ final class TransportFactory
         $nodePath = $config->nodePath ?? (new NodeBinaryResolver())->resolve();
         $command = [$nodePath, $serverScriptPath];
 
-        $transportConfig = [
-            'command' => $command,
-            'timeout' => $config->timeoutMs,
-            'cwd' => dirname($serverScriptPath), // Removed legacy cwd override
-            'env' => $config->env,
-            'verbose' => false, // TODO: Integrate with logger instead of verbose flag
-        ];
+        $processLauncher = new ProcessLauncher($logger);
 
-        return new ProcessTransport($transportConfig, $logger);
+        return new JsonRpcTransport(
+            $processLauncher,
+            [
+                'command' => $command,
+                'timeout' => $config->timeoutMs / 1000,
+                'cwd' => dirname($serverScriptPath),
+                'env' => $config->env,
+            ],
+            $logger
+        );
     }
 }

--- a/tests/Integration/Transport/TransportFactoryTest.php
+++ b/tests/Integration/Transport/TransportFactoryTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use PlaywrightPHP\Configuration\PlaywrightConfig;
-use PlaywrightPHP\Transport\ProcessTransport;
+use PlaywrightPHP\Transport\JsonRpc\JsonRpcTransport;
 use PlaywrightPHP\Transport\TransportFactory;
 use Psr\Log\NullLogger;
 
@@ -40,7 +40,7 @@ class TransportFactoryTest extends TestCase
 
         $transport = $this->factory->create($config, $this->logger);
 
-        $this->assertInstanceOf(ProcessTransport::class, $transport);
+        $this->assertInstanceOf(JsonRpcTransport::class, $transport);
     }
 
     #[Test]
@@ -49,7 +49,7 @@ class TransportFactoryTest extends TestCase
         $config = new PlaywrightConfig();
         $transport = $this->factory->create($config, $this->logger);
 
-        $this->assertInstanceOf(ProcessTransport::class, $transport);
+        $this->assertInstanceOf(JsonRpcTransport::class, $transport);
     }
 
     #[Test]
@@ -60,7 +60,7 @@ class TransportFactoryTest extends TestCase
         );
         $transport = $this->factory->create($config, $this->logger);
 
-        $this->assertInstanceOf(ProcessTransport::class, $transport);
+        $this->assertInstanceOf(JsonRpcTransport::class, $transport);
     }
 
     #[Test]
@@ -71,7 +71,7 @@ class TransportFactoryTest extends TestCase
         );
         $transport = $this->factory->create($config, $this->logger);
 
-        $this->assertInstanceOf(ProcessTransport::class, $transport);
+        $this->assertInstanceOf(JsonRpcTransport::class, $transport);
     }
 
     #[Test]
@@ -82,6 +82,6 @@ class TransportFactoryTest extends TestCase
         );
         $transport = $this->factory->create($config, $this->logger);
 
-        $this->assertInstanceOf(ProcessTransport::class, $transport);
+        $this->assertInstanceOf(JsonRpcTransport::class, $transport);
     }
 }

--- a/tests/Unit/Browser/BrowserContextTest.php
+++ b/tests/Unit/Browser/BrowserContextTest.php
@@ -1,0 +1,413 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the playwright-php/playwright package.
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace PlaywrightPHP\Tests\Unit\Browser;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use PlaywrightPHP\Browser\BrowserContext;
+use PlaywrightPHP\Configuration\PlaywrightConfig;
+use PlaywrightPHP\Network\NetworkThrottling;
+use PlaywrightPHP\Page\PageInterface;
+use PlaywrightPHP\Transport\TransportInterface;
+
+#[CoversClass(BrowserContext::class)]
+final class BrowserContextTest extends TestCase
+{
+    private TransportInterface $mockTransport;
+    private BrowserContext $context;
+    private PlaywrightConfig $config;
+
+    protected function setUp(): void
+    {
+        $this->mockTransport = $this->createMock(TransportInterface::class);
+        $this->config = new PlaywrightConfig();
+        $this->context = new BrowserContext($this->mockTransport, 'context_1', $this->config);
+    }
+
+    public function testNewPageSendsCorrectCommand(): void
+    {
+        $this->mockTransport
+            ->expects($this->once())
+            ->method('send')
+            ->with([
+                'action' => 'context.newPage',
+                'contextId' => 'context_1',
+                'options' => ['viewport' => ['width' => 1280, 'height' => 720]],
+            ])
+            ->willReturn(['pageId' => 'page_1']);
+
+        $page = $this->context->newPage(['viewport' => ['width' => 1280, 'height' => 720]]);
+
+        $this->assertInstanceOf(PageInterface::class, $page);
+    }
+
+    public function testNewPageThrowsOnTransportError(): void
+    {
+        $this->mockTransport
+            ->method('send')
+            ->willReturn(['error' => 'Failed to create page']);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Transport error in newPage: Failed to create page');
+
+        $this->context->newPage();
+    }
+
+    public function testNewPageThrowsOnInvalidPageId(): void
+    {
+        $this->mockTransport
+            ->method('send')
+            ->willReturn(['success' => true]); // Missing pageId
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('No valid pageId returned from transport in newPage');
+
+        $this->context->newPage();
+    }
+
+    public function testClipboardText(): void
+    {
+        $this->mockTransport
+            ->expects($this->once())
+            ->method('send')
+            ->with([
+                'action' => 'context.clipboardText',
+                'contextId' => 'context_1',
+            ])
+            ->willReturn(['value' => 'clipboard content']);
+
+        $result = $this->context->clipboardText();
+        $this->assertEquals('clipboard content', $result);
+    }
+
+    public function testClose(): void
+    {
+        $this->mockTransport
+            ->expects($this->once())
+            ->method('send')
+            ->with([
+                'action' => 'context.close',
+                'contextId' => 'context_1',
+            ]);
+
+        $this->context->close();
+    }
+
+    public function testAddCookies(): void
+    {
+        $cookies = [
+            ['name' => 'session', 'value' => 'abc123', 'domain' => 'example.com'],
+        ];
+
+        $this->mockTransport
+            ->expects($this->once())
+            ->method('send')
+            ->with([
+                'action' => 'context.addCookies',
+                'contextId' => 'context_1',
+                'cookies' => $cookies,
+            ]);
+
+        $this->context->addCookies($cookies);
+    }
+
+    public function testAddInitScript(): void
+    {
+        $script = 'window.testInit = true;';
+
+        $this->mockTransport
+            ->expects($this->once())
+            ->method('send')
+            ->with([
+                'action' => 'context.addInitScript',
+                'contextId' => 'context_1',
+                'script' => $script,
+            ]);
+
+        $this->context->addInitScript($script);
+    }
+
+    public function testClearCookies(): void
+    {
+        $this->mockTransport
+            ->expects($this->once())
+            ->method('send')
+            ->with([
+                'action' => 'context.clearCookies',
+                'contextId' => 'context_1',
+            ]);
+
+        $this->context->clearCookies();
+    }
+
+    public function testClearPermissions(): void
+    {
+        $this->mockTransport
+            ->expects($this->once())
+            ->method('send')
+            ->with([
+                'action' => 'context.clearPermissions',
+                'contextId' => 'context_1',
+            ]);
+
+        $this->context->clearPermissions();
+    }
+
+    public function testCookies(): void
+    {
+        $expectedCookies = [
+            ['name' => 'session', 'value' => 'abc123'],
+        ];
+
+        $this->mockTransport
+            ->expects($this->once())
+            ->method('send')
+            ->with([
+                'action' => 'context.cookies',
+                'contextId' => 'context_1',
+                'urls' => ['https://example.com'],
+            ])
+            ->willReturn(['cookies' => $expectedCookies]);
+
+        $result = $this->context->cookies(['https://example.com']);
+        $this->assertEquals($expectedCookies, $result);
+    }
+
+    public function testCookiesWithoutUrls(): void
+    {
+        $this->mockTransport
+            ->expects($this->once())
+            ->method('send')
+            ->with([
+                'action' => 'context.cookies',
+                'contextId' => 'context_1',
+                'urls' => null,
+            ])
+            ->willReturn(['cookies' => []]);
+
+        $result = $this->context->cookies();
+        $this->assertEquals([], $result);
+    }
+
+    public function testExposeBinding(): void
+    {
+        $callback = function ($source, $data) {
+            return 'processed: '.$data;
+        };
+
+        $this->mockTransport
+            ->expects($this->once())
+            ->method('send')
+            ->with([
+                'action' => 'context.exposeBinding',
+                'contextId' => 'context_1',
+                'name' => 'testBinding',
+            ]);
+
+        $this->context->exposeBinding('testBinding', $callback);
+    }
+
+    public function testExposeFunction(): void
+    {
+        $callback = function ($arg1, $arg2) {
+            return $arg1 + $arg2;
+        };
+
+        $this->mockTransport
+            ->expects($this->once())
+            ->method('send')
+            ->with([
+                'action' => 'context.exposeFunction',
+                'contextId' => 'context_1',
+                'name' => 'addNumbers',
+            ]);
+
+        $this->context->exposeFunction('addNumbers', $callback);
+    }
+
+    public function testGrantPermissions(): void
+    {
+        $permissions = ['camera', 'microphone'];
+
+        $this->mockTransport
+            ->expects($this->once())
+            ->method('send')
+            ->with([
+                'action' => 'context.grantPermissions',
+                'contextId' => 'context_1',
+                'permissions' => $permissions,
+            ]);
+
+        $this->context->grantPermissions($permissions);
+    }
+
+    public function testPagesReturnsEmptyArrayInitially(): void
+    {
+        $pages = $this->context->pages();
+        $this->assertEquals([], $pages);
+    }
+
+    public function testStorageState(): void
+    {
+        $expectedState = [
+            'cookies' => [['name' => 'session', 'value' => 'abc']],
+            'origins' => [],
+        ];
+
+        $this->mockTransport
+            ->expects($this->once())
+            ->method('send')
+            ->with([
+                'action' => 'context.storageState',
+                'contextId' => 'context_1',
+                'options' => ['path' => '/tmp/state.json'],
+            ])
+            ->willReturn(['storageState' => $expectedState]);
+
+        $result = $this->context->storageState('/tmp/state.json');
+        $this->assertEquals($expectedState, $result);
+    }
+
+    public function testStorageStateWithoutPath(): void
+    {
+        $this->mockTransport
+            ->expects($this->once())
+            ->method('send')
+            ->with([
+                'action' => 'context.storageState',
+                'contextId' => 'context_1',
+                'options' => [],
+            ])
+            ->willReturn(['storageState' => []]);
+
+        $result = $this->context->storageState();
+        $this->assertEquals([], $result);
+    }
+
+    public function testSetGeolocation(): void
+    {
+        $this->mockTransport
+            ->expects($this->once())
+            ->method('send')
+            ->with([
+                'action' => 'context.setGeolocation',
+                'contextId' => 'context_1',
+                'geolocation' => [
+                    'latitude' => 37.7749,
+                    'longitude' => -122.4194,
+                    'accuracy' => 10.0,
+                ],
+            ]);
+
+        $this->context->setGeolocation(37.7749, -122.4194, 10.0);
+    }
+
+    public function testSetOffline(): void
+    {
+        $this->mockTransport
+            ->expects($this->once())
+            ->method('send')
+            ->with([
+                'action' => 'context.setOffline',
+                'contextId' => 'context_1',
+                'offline' => true,
+            ]);
+
+        $this->context->setOffline(true);
+    }
+
+    public function testRoute(): void
+    {
+        $handler = function ($route) {
+            $route->fulfill(['body' => 'mocked']);
+        };
+
+        $this->mockTransport
+            ->expects($this->once())
+            ->method('send')
+            ->with([
+                'action' => 'context.route',
+                'contextId' => 'context_1',
+                'url' => '**/*.api',
+            ]);
+
+        $this->context->route('**/*.api', $handler);
+    }
+
+    public function testUnroute(): void
+    {
+        $this->mockTransport
+            ->expects($this->once())
+            ->method('send')
+            ->with([
+                'action' => 'context.unroute',
+                'contextId' => 'context_1',
+                'url' => '**/*.api',
+            ]);
+
+        $this->context->unroute('**/*.api');
+    }
+
+    public function testGetEnv(): void
+    {
+        $this->mockTransport
+            ->expects($this->once())
+            ->method('send')
+            ->with([
+                'action' => 'getEnv',
+                'name' => 'NODE_ENV',
+            ])
+            ->willReturn(['value' => 'test']);
+
+        $result = $this->context->getEnv('NODE_ENV');
+        $this->assertEquals('test', $result);
+    }
+
+    public function testGetEnvReturnsNullWhenNotSet(): void
+    {
+        $this->mockTransport
+            ->method('send')
+            ->willReturn([]);
+
+        $result = $this->context->getEnv('NONEXISTENT');
+        $this->assertNull($result);
+    }
+
+    public function testSetNetworkThrottling(): void
+    {
+        $throttling = NetworkThrottling::slow3G();
+
+        $this->mockTransport
+            ->expects($this->once())
+            ->method('send')
+            ->with([
+                'action' => 'context.setNetworkThrottling',
+                'contextId' => 'context_1',
+                'throttling' => $throttling->toArray(),
+            ]);
+
+        $this->context->setNetworkThrottling($throttling);
+    }
+
+    public function testDisableNetworkThrottling(): void
+    {
+        $this->mockTransport
+            ->expects($this->once())
+            ->method('send')
+            ->with([
+                'action' => 'context.setNetworkThrottling',
+                'contextId' => 'context_1',
+                'throttling' => NetworkThrottling::none()->toArray(),
+            ]);
+
+        $this->context->disableNetworkThrottling();
+    }
+}

--- a/tests/Unit/Event/EventEmitterTest.php
+++ b/tests/Unit/Event/EventEmitterTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the playwright-php/playwright package.
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace PlaywrightPHP\Tests\Unit\Event;
+
+use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\TestCase;
+use PlaywrightPHP\Event\EventEmitter;
+
+#[CoversTrait(EventEmitter::class)]
+final class EventEmitterTest extends TestCase
+{
+    private TestEventEmitter $emitter;
+
+    protected function setUp(): void
+    {
+        $this->emitter = new TestEventEmitter();
+    }
+
+    public function testOnAddsListener(): void
+    {
+        $called = false;
+        $this->emitter->on('test', function () use (&$called) {
+            $called = true;
+        });
+
+        $this->emitter->triggerEvent('test');
+        $this->assertTrue($called);
+    }
+
+    public function testMultipleListenersForSameEvent(): void
+    {
+        $calls = [];
+        $this->emitter->on('test', function () use (&$calls) {
+            $calls[] = 'first';
+        });
+        $this->emitter->on('test', function () use (&$calls) {
+            $calls[] = 'second';
+        });
+
+        $this->emitter->triggerEvent('test');
+        $this->assertEquals(['first', 'second'], $calls);
+    }
+
+    public function testOnceRemovesListenerAfterFirstCall(): void
+    {
+        $callCount = 0;
+        $this->emitter->once('test', function () use (&$callCount) {
+            ++$callCount;
+        });
+
+        $this->emitter->triggerEvent('test');
+        $this->emitter->triggerEvent('test');
+        $this->assertEquals(1, $callCount);
+    }
+
+    public function testListenerReceivesArguments(): void
+    {
+        $receivedArgs = null;
+        $this->emitter->on('test', function (...$args) use (&$receivedArgs) {
+            $receivedArgs = $args;
+        });
+
+        $this->emitter->triggerEvent('test', ['arg1', 'arg2', 123]);
+        $this->assertEquals(['arg1', 'arg2', 123], $receivedArgs);
+    }
+
+    public function testRemoveListenerRemovesSpecificListener(): void
+    {
+        $firstCalled = false;
+        $secondCalled = false;
+
+        $firstListener = function () use (&$firstCalled) {
+            $firstCalled = true;
+        };
+        $secondListener = function () use (&$secondCalled) {
+            $secondCalled = true;
+        };
+
+        $this->emitter->on('test', $firstListener);
+        $this->emitter->on('test', $secondListener);
+        $this->emitter->removeListener('test', $firstListener);
+
+        $this->emitter->triggerEvent('test');
+        $this->assertFalse($firstCalled);
+        $this->assertTrue($secondCalled);
+    }
+
+    public function testRemoveListenerForNonExistentEvent(): void
+    {
+        $listener = function () {
+        };
+
+        // Should not throw
+        $this->emitter->removeListener('nonexistent', $listener);
+        $this->assertTrue(true);
+    }
+
+    public function testRemoveNonExistentListener(): void
+    {
+        $listener1 = function () {
+        };
+        $listener2 = function () {
+        };
+
+        $this->emitter->on('test', $listener1);
+
+        // Should not throw
+        $this->emitter->removeListener('test', $listener2);
+        $this->assertTrue(true);
+    }
+
+    public function testEmitWithNoListeners(): void
+    {
+        // Should not throw
+        $this->emitter->triggerEvent('nonexistent');
+        $this->assertTrue(true);
+    }
+
+    public function testOnceWithMultipleEvents(): void
+    {
+        $calls = [];
+        $this->emitter->once('event1', function () use (&$calls) {
+            $calls[] = 'event1';
+        });
+        $this->emitter->once('event2', function () use (&$calls) {
+            $calls[] = 'event2';
+        });
+
+        $this->emitter->triggerEvent('event1');
+        $this->emitter->triggerEvent('event2');
+        $this->emitter->triggerEvent('event1'); // Should not call again
+        $this->emitter->triggerEvent('event2'); // Should not call again
+
+        $this->assertEquals(['event1', 'event2'], $calls);
+    }
+}
+
+/**
+ * Test class that uses EventEmitter trait for testing.
+ */
+final class TestEventEmitter
+{
+    use EventEmitter;
+
+    public function triggerEvent(string $event, array $args = []): void
+    {
+        $this->emit($event, $args);
+    }
+}

--- a/tests/Unit/Testing/PlaywrightTestCaseTest.php
+++ b/tests/Unit/Testing/PlaywrightTestCaseTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the playwright-php/playwright package.
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace PlaywrightPHP\Tests\Unit\Testing;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesTrait;
+use PHPUnit\Framework\TestCase;
+use PlaywrightPHP\Testing\PlaywrightTestCase;
+use PlaywrightPHP\Testing\PlaywrightTestCaseTrait;
+
+#[CoversClass(PlaywrightTestCase::class)]
+#[UsesTrait(PlaywrightTestCaseTrait::class)]
+final class PlaywrightTestCaseTest extends TestCase
+{
+    public function testPlaywrightTestCaseExtendsTestCase(): void
+    {
+        $reflection = new \ReflectionClass(PlaywrightTestCase::class);
+        $this->assertTrue($reflection->isSubclassOf(TestCase::class));
+    }
+
+    public function testPlaywrightTestCaseUsesTraitMethods(): void
+    {
+        $reflection = new \ReflectionClass(PlaywrightTestCase::class);
+
+        // Verify trait methods are available
+        $this->assertTrue($reflection->hasMethod('setUpPlaywright'));
+        $this->assertTrue($reflection->hasMethod('tearDownPlaywright'));
+        $this->assertTrue($reflection->hasMethod('expect'));
+        $this->assertTrue($reflection->hasMethod('assertElementExists'));
+    }
+
+    public function testTraitPropertiesAreAvailable(): void
+    {
+        $reflection = new \ReflectionClass(PlaywrightTestCase::class);
+
+        // Verify trait properties are accessible
+        $this->assertTrue($reflection->hasProperty('playwright'));
+        $this->assertTrue($reflection->hasProperty('browser'));
+        $this->assertTrue($reflection->hasProperty('context'));
+        $this->assertTrue($reflection->hasProperty('page'));
+    }
+
+    public function testSetUpCallsSetUpPlaywright(): void
+    {
+        $reflection = new \ReflectionClass(PlaywrightTestCase::class);
+
+        // Verify setUp and tearDown methods exist and call trait methods
+        $this->assertTrue($reflection->hasMethod('setUp'));
+        $this->assertTrue($reflection->hasMethod('tearDown'));
+
+        $setUpMethod = $reflection->getMethod('setUp');
+        $this->assertTrue($setUpMethod->hasReturnType());
+        $this->assertEquals('void', $setUpMethod->getReturnType()->getName());
+    }
+}

--- a/tests/Unit/Transport/JsonRpc/JsonRpcClientInterfaceTest.php
+++ b/tests/Unit/Transport/JsonRpc/JsonRpcClientInterfaceTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the playwright-php/playwright package.
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace PlaywrightPHP\Tests\Unit\Transport\JsonRpc;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use PlaywrightPHP\Tests\Mocks\TestLogger;
+use PlaywrightPHP\Transport\JsonRpc\JsonRpcClient;
+use PlaywrightPHP\Transport\JsonRpc\JsonRpcClientInterface;
+use Symfony\Component\Clock\MockClock;
+
+#[CoversClass(JsonRpcClient::class)]
+final class JsonRpcClientInterfaceTest extends TestCase
+{
+    private MockClock $clock;
+    private TestLogger $logger;
+    private JsonRpcClientInterface $client;
+
+    protected function setUp(): void
+    {
+        $this->clock = new MockClock();
+        $this->logger = new TestLogger();
+        $this->client = new TestableJsonRpcClientWithInterface($this->clock, $this->logger);
+    }
+
+    public function testSendRawUsesRequestIdFormat(): void
+    {
+        $client = $this->client;
+        assert($client instanceof TestableJsonRpcClientWithInterface);
+
+        $client->setMockResponse(['requestId' => 1, 'browserId' => 'browser_1', 'status' => 'ok']);
+
+        $message = ['action' => 'launch', 'browser' => 'chromium', 'options' => ['headless' => true]];
+        $result = $client->sendRaw($message);
+
+        $requests = $client->getSentRequests();
+        $this->assertCount(1, $requests);
+
+        $sentRequest = $requests[0];
+        $this->assertEquals('launch', $sentRequest['action']);
+        $this->assertEquals('chromium', $sentRequest['browser']);
+        $this->assertEquals(['headless' => true], $sentRequest['options']);
+        $this->assertEquals(1, $sentRequest['requestId']);
+        $this->assertArrayNotHasKey('id', $sentRequest);
+        $this->assertArrayNotHasKey('jsonrpc', $sentRequest);
+
+        $this->assertEquals(['requestId' => 1, 'browserId' => 'browser_1', 'status' => 'ok'], $result);
+    }
+
+    public function testSendJsonRpcUsesIdFormat(): void
+    {
+        $client = $this->client;
+        assert($client instanceof TestableJsonRpcClientWithInterface);
+
+        $client->setMockResponse(['jsonrpc' => '2.0', 'id' => 1, 'result' => ['status' => 'success']]);
+
+        $result = $client->send('Browser.getVersion', ['param' => 'value']);
+
+        $requests = $client->getSentRequests();
+        $this->assertCount(1, $requests);
+
+        $sentRequest = $requests[0];
+        $this->assertEquals('Browser.getVersion', $sentRequest['method']);
+        $this->assertEquals(['param' => 'value'], $sentRequest['params']);
+        $this->assertEquals(1, $sentRequest['id']);
+        $this->assertEquals('2.0', $sentRequest['jsonrpc']);
+        $this->assertArrayNotHasKey('requestId', $sentRequest);
+
+        $this->assertEquals(['status' => 'success'], $result);
+    }
+
+    public function testDualIdSupportInInterface(): void
+    {
+        $client = $this->client;
+        assert($client instanceof TestableJsonRpcClientWithInterface);
+
+        // First: JSON-RPC with id
+        $client->setMockResponse(['jsonrpc' => '2.0', 'id' => 1, 'result' => ['type' => 'jsonrpc']]);
+        $result1 = $client->send('test.jsonrpc');
+        $this->assertEquals(['type' => 'jsonrpc'], $result1);
+
+        // Second: Raw with requestId
+        $client->setMockResponse(['requestId' => 2, 'type' => 'raw']);
+        $result2 = $client->sendRaw(['action' => 'test']);
+        $this->assertEquals(['requestId' => 2, 'type' => 'raw'], $result2);
+
+        $requests = $client->getSentRequests();
+        $this->assertCount(2, $requests);
+
+        // Verify different ID fields used
+        $this->assertArrayHasKey('id', $requests[0]);
+        $this->assertArrayNotHasKey('requestId', $requests[0]);
+        $this->assertArrayHasKey('requestId', $requests[1]);
+        $this->assertArrayNotHasKey('id', $requests[1]);
+    }
+
+    public function testPendingRequestsTracking(): void
+    {
+        $pending = $this->client->getPendingRequests();
+        $this->assertEmpty($pending);
+
+        $this->client->cancelPendingRequests();
+
+        $pendingAfter = $this->client->getPendingRequests();
+        $this->assertEmpty($pendingAfter);
+    }
+}
+
+/**
+ * Testable implementation of JsonRpcClientInterface for testing dual ID support.
+ */
+final class TestableJsonRpcClientWithInterface extends JsonRpcClient
+{
+    private array $sentRequests = [];
+    private ?array $mockResponse = null;
+
+    public function setMockResponse(?array $response): void
+    {
+        $this->mockResponse = $response;
+    }
+
+    public function getSentRequests(): array
+    {
+        return $this->sentRequests;
+    }
+
+    protected function sendAndReceive(array $request, ?float $deadline): array
+    {
+        $this->sentRequests[] = $request;
+
+        if (null === $this->mockResponse) {
+            throw new \RuntimeException('No mock response set');
+        }
+
+        return $this->mockResponse;
+    }
+}

--- a/tests/Unit/Transport/JsonRpc/LspFramingTest.php
+++ b/tests/Unit/Transport/JsonRpc/LspFramingTest.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the playwright-php/playwright package.
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace PlaywrightPHP\Tests\Unit\Transport\JsonRpc;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use PlaywrightPHP\Transport\JsonRpc\LspFraming;
+
+#[CoversClass(LspFraming::class)]
+final class LspFramingTest extends TestCase
+{
+    public function testEncoding(): void
+    {
+        $json = '{"jsonrpc":"2.0","id":1}';
+        $encoded = LspFraming::encode($json);
+        $expected = "Content-Length: 24\r\n\r\n{\"jsonrpc\":\"2.0\",\"id\":1}";
+        
+        self::assertSame($expected, $encoded);
+    }
+
+    public function testEncodingWithDifferentSizes(): void
+    {
+        $testCases = [
+            '{"test":1}' => "Content-Length: 10\r\n\r\n{\"test\":1}",
+            '' => "Content-Length: 0\r\n\r\n",
+            'hello' => "Content-Length: 5\r\n\r\nhello",
+        ];
+
+        foreach ($testCases as $input => $expected) {
+            self::assertSame($expected, LspFraming::encode($input), "Failed for input: {$input}");
+        }
+    }
+
+    public function testDecodingSingleCompleteMessage(): void
+    {
+        $framed = "Content-Length: 24\r\n\r\n{\"jsonrpc\":\"2.0\",\"id\":1}";
+        $decoded = LspFraming::decode($framed);
+        
+        self::assertCount(1, $decoded['messages']);
+        self::assertSame('{"jsonrpc":"2.0","id":1}', $decoded['messages'][0]);
+        self::assertSame('', $decoded['remainingBuffer']);
+    }
+
+    public function testDecodingIncompleteMessage(): void
+    {
+        $testCases = [
+            'Content-Length: 25', // Header only
+            "Content-Length: 25\r\n", // Incomplete header separator
+            "Content-Length: 25\r\n\r\n{\"jsonrpc\":", // Partial payload
+            "Content-Length: 25\r\n\r\n{\"jsonrpc\":\"2.0\"", // Incomplete payload
+        ];
+
+        foreach ($testCases as $incomplete) {
+            $decoded = LspFraming::decode($incomplete);
+            self::assertEmpty($decoded['messages'], "Should have no messages for: {$incomplete}");
+            self::assertSame($incomplete, $decoded['remainingBuffer'], "Buffer should be unchanged for: {$incomplete}");
+        }
+    }
+
+    public function testDecodingMultipleMessages(): void
+    {
+        $message1 = '{"id":1}';
+        $message2 = '{"id":2}';
+        $framed1 = LspFraming::encode($message1);
+        $framed2 = LspFraming::encode($message2);
+        $combined = $framed1 . $framed2;
+        
+        $decoded = LspFraming::decode($combined);
+        
+        self::assertCount(2, $decoded['messages']);
+        self::assertSame($message1, $decoded['messages'][0]);
+        self::assertSame($message2, $decoded['messages'][1]);
+        self::assertSame('', $decoded['remainingBuffer']);
+    }
+
+    public function testDecodingWithTrailingData(): void
+    {
+        $completeMessage = '{"id":1}';
+        $framed = LspFraming::encode($completeMessage);
+        $trailingData = 'Content-Length: 50';
+        $input = $framed . $trailingData;
+        
+        $decoded = LspFraming::decode($input);
+        
+        self::assertCount(1, $decoded['messages']);
+        self::assertSame($completeMessage, $decoded['messages'][0]);
+        self::assertSame($trailingData, $decoded['remainingBuffer']);
+    }
+
+    public function testDecodingMultipleMessagesWithTrailingData(): void
+    {
+        $message1 = '{"id":1}';
+        $message2 = '{"id":2}';
+        $framed1 = LspFraming::encode($message1);
+        $framed2 = LspFraming::encode($message2);
+        $trailingData = 'Content-Length: 100\r\n\r\nincomplete';
+        $input = $framed1 . $framed2 . $trailingData;
+        
+        $decoded = LspFraming::decode($input);
+        
+        self::assertCount(2, $decoded['messages']);
+        self::assertSame($message1, $decoded['messages'][0]);
+        self::assertSame($message2, $decoded['messages'][1]);
+        self::assertSame($trailingData, $decoded['remainingBuffer']);
+    }
+
+    public function testHasCompleteMessage(): void
+    {
+        $completeMessage = LspFraming::encode('{"test":1}');
+        self::assertTrue(LspFraming::hasCompleteMessage($completeMessage));
+
+        $incompleteMessage = 'Content-Length: 10\r\n\r\n{"te';
+        self::assertFalse(LspFraming::hasCompleteMessage($incompleteMessage));
+
+        $headerOnly = 'Content-Length: 10';
+        self::assertFalse(LspFraming::hasCompleteMessage($headerOnly));
+
+        self::assertFalse(LspFraming::hasCompleteMessage(''));
+    }
+
+    public function testGetExpectedLength(): void
+    {
+        $headerComplete = "Content-Length: 25\r\n\r\n";
+        self::assertSame(47, LspFraming::getExpectedLength($headerComplete)); // 22 (header) + 25 (content)
+
+        $headerIncomplete = 'Content-Length: 25';
+        self::assertNull(LspFraming::getExpectedLength($headerIncomplete));
+
+        $noHeader = 'some random data';
+        self::assertNull(LspFraming::getExpectedLength($noHeader));
+
+        self::assertNull(LspFraming::getExpectedLength(''));
+    }
+
+    public function testInvalidContentLength(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Missing or invalid Content-Length header');
+        
+        LspFraming::decode("Invalid-Header: 25\r\n\r\ncontent");
+    }
+
+    public function testLargePayload(): void
+    {
+        $largeContent = str_repeat('x', 1000000); // 1MB
+        $encoded = LspFraming::encode($largeContent);
+        $decoded = LspFraming::decode($encoded);
+        
+        self::assertCount(1, $decoded['messages']);
+        self::assertSame($largeContent, $decoded['messages'][0]);
+        self::assertSame('', $decoded['remainingBuffer']);
+    }
+
+    public function testMultiByteCharacters(): void
+    {
+        $utf8Content = '{"text":"こんにちは世界🌍"}';
+        $encoded = LspFraming::encode($utf8Content);
+        $decoded = LspFraming::decode($encoded);
+        
+        self::assertCount(1, $decoded['messages']);
+        self::assertSame($utf8Content, $decoded['messages'][0]);
+        self::assertSame('', $decoded['remainingBuffer']);
+    }
+
+    public function testEdgeCaseHeaders(): void
+    {
+        $testCases = [
+            "content-length: 5\r\n\r\nhello", // lowercase
+            "Content-Length:5\r\n\r\nhello", // no space after colon
+            "Content-Length: 5 \r\n\r\nhello", // trailing space
+        ];
+
+        foreach ($testCases as $input) {
+            $decoded = LspFraming::decode($input);
+            self::assertCount(1, $decoded['messages'], "Failed for: {$input}");
+            self::assertSame('hello', $decoded['messages'][0]);
+        }
+    }
+}

--- a/tests/Unit/Transport/JsonRpc/ProcessJsonRpcClientTest.php
+++ b/tests/Unit/Transport/JsonRpc/ProcessJsonRpcClientTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the playwright-php/playwright package.
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace PlaywrightPHP\Tests\Unit\Transport\JsonRpc;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use PlaywrightPHP\Exception\DisconnectedException;
+use PlaywrightPHP\Exception\NetworkException;
+use PlaywrightPHP\Tests\Mocks\TestLogger;
+use PlaywrightPHP\Transport\JsonRpc\JsonRpcClientInterface;
+use PlaywrightPHP\Transport\JsonRpc\ProcessJsonRpcClient;
+use PlaywrightPHP\Transport\JsonRpc\ProcessLauncherInterface;
+use Symfony\Component\Clock\MockClock;
+use Symfony\Component\Process\InputStream;
+use Symfony\Component\Process\Process;
+
+#[CoversClass(ProcessJsonRpcClient::class)]
+final class ProcessJsonRpcClientTest extends TestCase
+{
+    private MockClock $clock;
+    private TestLogger $logger;
+    private Process $mockProcess;
+    private ProcessLauncherInterface $mockProcessLauncher;
+    private InputStream $mockInputStream;
+    private ProcessJsonRpcClient $client;
+
+    protected function setUp(): void
+    {
+        $this->clock = new MockClock();
+        $this->logger = new TestLogger();
+        $this->mockProcess = $this->createMock(Process::class);
+        $this->mockProcessLauncher = $this->createMock(ProcessLauncherInterface::class);
+        $this->mockInputStream = $this->createMock(InputStream::class);
+
+        // Setup basic mocks
+        $this->mockProcess->method('isRunning')->willReturn(true);
+        $this->mockProcess->method('getPid')->willReturn(12345);
+        $this->mockProcessLauncher->method('getInputStream')->willReturn($this->mockInputStream);
+        $this->mockProcessLauncher->method('ensureRunning');
+
+        $this->client = new ProcessJsonRpcClient(
+            process: $this->mockProcess,
+            processLauncher: $this->mockProcessLauncher,
+            clock: $this->clock,
+            logger: $this->logger,
+            defaultTimeoutMs: 1000.0
+        );
+    }
+
+    public function testConstructorRequiresInputStream(): void
+    {
+        $mockProcessLauncherWithoutStream = $this->createMock(ProcessLauncherInterface::class);
+        $mockProcessLauncherWithoutStream
+            ->method('getInputStream')
+            ->willReturn(null);
+
+        $this->expectException(NetworkException::class);
+        $this->expectExceptionMessage('ProcessLauncher must have an InputStream for JSON-RPC communication');
+
+        new ProcessJsonRpcClient(
+            process: $this->mockProcess,
+            processLauncher: $mockProcessLauncherWithoutStream,
+            clock: $this->clock,
+            logger: $this->logger
+        );
+    }
+
+    public function testProcessJsonRpcClientCreationSucceedsWithInputStream(): void
+    {
+        $client = new ProcessJsonRpcClient(
+            process: $this->mockProcess,
+            processLauncher: $this->mockProcessLauncher,
+            clock: $this->clock,
+            logger: $this->logger
+        );
+
+        $this->assertInstanceOf(ProcessJsonRpcClient::class, $client);
+    }
+
+    public function testImplementsJsonRpcClientInterface(): void
+    {
+        $this->assertInstanceOf(JsonRpcClientInterface::class, $this->client);
+    }
+
+    public function testProcessNotRunningThrowsDisconnectedException(): void
+    {
+        $mockProcess = $this->createMock(Process::class);
+        $mockProcessLauncher = $this->createMock(ProcessLauncherInterface::class);
+        $mockInputStream = $this->createMock(InputStream::class);
+        
+        $mockProcess->method('isRunning')->willReturn(false);
+        $mockProcess->method('getExitCode')->willReturn(1);
+        $mockProcess->method('getPid')->willReturn(12345);
+        $mockProcessLauncher->method('getInputStream')->willReturn($mockInputStream);
+        
+        $client = new ProcessJsonRpcClient(
+            process: $mockProcess,
+            processLauncher: $mockProcessLauncher,
+            clock: $this->clock,
+            logger: $this->logger
+        );
+        
+        $this->expectException(DisconnectedException::class);
+        $this->expectExceptionMessage('Process exited with code 1');
+        
+        $client->send('test.method');
+    }
+
+    public function testInputStreamWriteFailureThrowsNetworkException(): void
+    {
+        $mockInputStream = $this->createMock(InputStream::class);
+        $mockInputStream
+            ->method('write')
+            ->willThrowException(new \RuntimeException('Write failed'));
+        
+        $mockProcess = $this->createMock(Process::class);
+        $mockProcessLauncher = $this->createMock(ProcessLauncherInterface::class);
+        
+        $mockProcess->method('isRunning')->willReturn(true);
+        $mockProcess->method('getPid')->willReturn(12345);
+        $mockProcessLauncher->method('getInputStream')->willReturn($mockInputStream);
+        $mockProcessLauncher->method('ensureRunning');
+        
+        $client = new ProcessJsonRpcClient(
+            process: $mockProcess,
+            processLauncher: $mockProcessLauncher,
+            clock: $this->clock,
+            logger: $this->logger
+        );
+        
+        $this->expectException(NetworkException::class);
+        $this->expectExceptionMessage('Failed to write to process stdin: Write failed');
+        
+        $client->send('test.method');
+    }
+}

--- a/tests/Unit/Transport/JsonRpcTransportTest.php
+++ b/tests/Unit/Transport/JsonRpcTransportTest.php
@@ -16,6 +16,7 @@ use PlaywrightPHP\Exception\NetworkException;
 use PlaywrightPHP\Tests\Mocks\TestLogger;
 use PlaywrightPHP\Transport\JsonRpc\JsonRpcTransport;
 use PlaywrightPHP\Transport\JsonRpc\ProcessLauncherInterface;
+use Symfony\Component\Process\InputStream;
 use Symfony\Component\Process\Process;
 
 #[CoversClass(JsonRpcTransport::class)]
@@ -36,10 +37,16 @@ final class JsonRpcTransportTest extends TestCase
         $mockProcess->method('isRunning')->willReturn(true);
         $mockProcess->method('getPid')->willReturn(12345);
 
+        $mockInputStream = $this->createMock(InputStream::class);
+
         $this->processLauncher
             ->expects($this->once())
             ->method('start')
             ->willReturn($mockProcess);
+
+        $this->processLauncher
+            ->method('getInputStream')
+            ->willReturn($mockInputStream);
 
         $transport = new JsonRpcTransport(
             processLauncher: $this->processLauncher,
@@ -87,9 +94,15 @@ final class JsonRpcTransportTest extends TestCase
         $mockProcess->method('isRunning')->willReturn(false);
         $mockProcess->method('getPid')->willReturn(12345);
 
+        $mockInputStream = $this->createMock(InputStream::class);
+
         $this->processLauncher
             ->method('start')
             ->willReturn($mockProcess);
+
+        $this->processLauncher
+            ->method('getInputStream')
+            ->willReturn($mockInputStream);
 
         $transport = new JsonRpcTransport(
             processLauncher: $this->processLauncher,
@@ -109,9 +122,15 @@ final class JsonRpcTransportTest extends TestCase
         $mockProcess->expects($this->once())
             ->method('stop');
 
+        $mockInputStream = $this->createMock(InputStream::class);
+
         $this->processLauncher
             ->method('start')
             ->willReturn($mockProcess);
+
+        $this->processLauncher
+            ->method('getInputStream')
+            ->willReturn($mockInputStream);
 
         $transport = new JsonRpcTransport(
             processLauncher: $this->processLauncher,
@@ -172,9 +191,15 @@ final class JsonRpcTransportTest extends TestCase
         $mockProcess->expects($this->once())
             ->method('stop');
 
+        $mockInputStream = $this->createMock(InputStream::class);
+
         $this->processLauncher
             ->method('start')
             ->willReturn($mockProcess);
+
+        $this->processLauncher
+            ->method('getInputStream')
+            ->willReturn($mockInputStream);
 
         $transport = new JsonRpcTransport(
             processLauncher: $this->processLauncher,


### PR DESCRIPTION
This PR modernizes the transport layer with a new `JsonRpcClientInterface`, standardizing how clients send requests and raw messages.
It introduces LSP framing for message encoding/decoding, ensuring smooth interoperability with Node.js servers.
