### PR TITLE
Make `PlaywrightConfig` mandatory

### DIFF
--- a/src/Browser/Browser.php
+++ b/src/Browser/Browser.php
@@ -35,7 +35,7 @@ final class Browser implements BrowserInterface
         private readonly string $browserId,
         private readonly string $defaultContextId,
         private readonly string $version,
-        private readonly ?PlaywrightConfig $config = null,
+        private readonly PlaywrightConfig $config,
     ) {
         $this->defaultContext = new BrowserContext($this->transport, $this->defaultContextId, $this->config);
         $this->contexts[] = $this->defaultContext;

--- a/src/Browser/BrowserBuilder.php
+++ b/src/Browser/BrowserBuilder.php
@@ -30,7 +30,7 @@ final class BrowserBuilder
         private readonly string $browserType,
         private readonly TransportInterface $transport,
         private readonly LoggerInterface $logger,
-        private readonly ?PlaywrightConfig $config = null,
+        private readonly PlaywrightConfig $config,
     ) {
     }
 

--- a/src/Browser/BrowserContext.php
+++ b/src/Browser/BrowserContext.php
@@ -56,7 +56,7 @@ final class BrowserContext implements BrowserContextInterface, EventDispatcherIn
     public function __construct(
         private readonly TransportInterface $transport,
         private readonly string $contextId,
-        private readonly ?PlaywrightConfig $config = null,
+        private readonly PlaywrightConfig $config,
     ) {
         if (method_exists($this->transport, 'addEventDispatcher')) {
             $this->transport->addEventDispatcher($this->contextId, $this);

--- a/src/Page/Page.php
+++ b/src/Page/Page.php
@@ -76,8 +76,6 @@ final class Page implements PageInterface, EventDispatcherInterface
 
     private PageEventHandlerInterface $eventHandler;
 
-    private LoggerInterface $logger;
-
     private ?APIRequestContextInterface $apiRequestContext = null;
 
     private bool $isClosed = false;
@@ -91,11 +89,9 @@ final class Page implements PageInterface, EventDispatcherInterface
         private readonly TransportInterface $transport,
         private readonly BrowserContextInterface $context,
         private readonly string $pageId,
-        private readonly ?PlaywrightConfig $config = null,
-        ?LoggerInterface $logger = null,
+        private readonly PlaywrightConfig $config,
+        private readonly LoggerInterface $logger = new NullLogger(),
     ) {
-        $this->logger = $logger ?? new NullLogger();
-
         $this->keyboard = new Keyboard($this->transport, $this->pageId);
         $this->mouse = new Mouse($this->transport, $this->pageId);
         $this->eventHandler = new PageEventHandler();
@@ -440,11 +436,7 @@ final class Page implements PageInterface, EventDispatcherInterface
      */
     private function getScreenshotDirectory(): string
     {
-        if (null !== $this->config) {
-            return $this->config->getScreenshotDirectory();
-        }
-
-        return rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.'playwright';
+        return $this->config->getScreenshotDirectory();
     }
 
     private function getPdfDirectory(): string

--- a/src/PlaywrightFactory.php
+++ b/src/PlaywrightFactory.php
@@ -42,15 +42,9 @@ use Psr\Log\NullLogger;
 class PlaywrightFactory
 {
     public static function create(
-        ?PlaywrightConfig $config = null,
-        ?LoggerInterface $logger = null,
+        PlaywrightConfig $config = new PlaywrightConfig(),
+        LoggerInterface $logger = new NullLogger(),
     ): PlaywrightClient {
-        $config ??= new PlaywrightConfig();
-        $logger ??= new NullLogger();
-
-        $transportFactory = new TransportFactory();
-        $transport = $transportFactory->create($config, $logger);
-
-        return new PlaywrightClient($transport, $logger, $config);
+        return new PlaywrightClient((new TransportFactory())->create($config, $logger), $logger, $config);
     }
 }

--- a/src/Testing/PlaywrightTestCaseTrait.php
+++ b/src/Testing/PlaywrightTestCaseTrait.php
@@ -25,6 +25,7 @@ use Playwright\Page\PageInterface;
 use Playwright\PlaywrightClient;
 use Playwright\PlaywrightFactory;
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Symfony\Component\Process\ExecutableFinder;
 
 trait PlaywrightTestCaseTrait
@@ -45,16 +46,22 @@ trait PlaywrightTestCaseTrait
 
     private bool $traceThisTest = false;
 
-    protected function setUpPlaywright(?LoggerInterface $logger = null, ?PlaywrightConfig $customConfig = null): void
+    private static ?string $nodePath = null;
+
+    protected function setUpPlaywright(LoggerInterface $logger = new NullLogger(), ?PlaywrightConfig $customConfig = null): void
     {
         $logger = $this->resolveLogger($logger);
 
-        $node = (new ExecutableFinder())->find('node');
-        if (null === $node) {
-            self::markTestSkipped('Node.js executable not found.');
+        if (null === self::$nodePath) {
+            $node = (new ExecutableFinder())->find('node');
+            if (null === $node) {
+                self::markTestSkipped('Node.js executable not found.');
+            }
+
+            self::$nodePath = $node;
         }
 
-        $config = $this->buildConfig($node, $customConfig);
+        $config = $this->buildConfig(self::$nodePath, $customConfig);
 
         if (null !== $customConfig) {
             $this->usingShared = false;
@@ -121,7 +128,7 @@ trait PlaywrightTestCaseTrait
         return new ExpectDecorator(new Expect($subject), $this);
     }
 
-    private function resolveLogger(?LoggerInterface $logger): ?LoggerInterface
+    private function resolveLogger(LoggerInterface $logger): LoggerInterface
     {
         $loggerUrl = $_SERVER['PLAYWRIGHT_PHP_TEST_LOGGER_URL'] ?? null;
         if (is_string($loggerUrl)) {
@@ -140,7 +147,7 @@ trait PlaywrightTestCaseTrait
         return $custom->withNodePath($node);
     }
 
-    private function initializeShared(PlaywrightConfig $config, ?LoggerInterface $logger): void
+    private function initializeShared(PlaywrightConfig $config, LoggerInterface $logger): void
     {
         if (null === self::$sharedPlaywright) {
             self::$sharedPlaywright = PlaywrightFactory::create($config, $logger);

--- a/tests/Integration/Browser/BrowserBuilderTest.php
+++ b/tests/Integration/Browser/BrowserBuilderTest.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Playwright\Browser\Browser;
 use Playwright\Browser\BrowserBuilder;
+use Playwright\Configuration\PlaywrightConfig;
 use Playwright\Transport\TransportInterface;
 use Psr\Log\NullLogger;
 
@@ -33,7 +34,7 @@ class BrowserBuilderTest extends TestCase
     {
         $this->transport = $this->createMock(TransportInterface::class);
         $this->logger = new NullLogger();
-        $this->builder = new BrowserBuilder('chromium', $this->transport, $this->logger);
+        $this->builder = new BrowserBuilder('chromium', $this->transport, $this->logger, new PlaywrightConfig());
     }
 
     #[Test]
@@ -133,8 +134,8 @@ class BrowserBuilderTest extends TestCase
     #[Test]
     public function itWorksWithDifferentBrowserTypes(): void
     {
-        $firefoxBuilder = new BrowserBuilder('firefox', $this->transport, $this->logger);
-        $webkitBuilder = new BrowserBuilder('webkit', $this->transport, $this->logger);
+        $firefoxBuilder = new BrowserBuilder('firefox', $this->transport, $this->logger, new PlaywrightConfig());
+        $webkitBuilder = new BrowserBuilder('webkit', $this->transport, $this->logger, new PlaywrightConfig());
 
         $this->assertInstanceOf(BrowserBuilder::class, $firefoxBuilder);
         $this->assertInstanceOf(BrowserBuilder::class, $webkitBuilder);

--- a/tests/Integration/Page/PdfIntegrationTest.php
+++ b/tests/Integration/Page/PdfIntegrationTest.php
@@ -40,7 +40,7 @@ final class PdfIntegrationTest extends TestCase
             headless: true
         );
 
-        $this->setUpPlaywright(null, $config);
+        $this->setUpPlaywright(customConfig: $config);
         $this->installRouteServer($this->page, [
             '/invoice.html' => <<<'HTML'
                 <!DOCTYPE html>

--- a/tests/Integration/Page/ScreenshotIntegrationTest.php
+++ b/tests/Integration/Page/ScreenshotIntegrationTest.php
@@ -49,7 +49,7 @@ class ScreenshotIntegrationTest extends TestCase
             headless: true
         );
 
-        $this->setUpPlaywright(null, $config);
+        $this->setUpPlaywright(customConfig: $config);
         $this->installRouteServer($this->page, [
             '/index.html' => <<<'HTML'
                 <!DOCTYPE html>

--- a/tests/Integration/PlaywrightFactoryTest.php
+++ b/tests/Integration/PlaywrightFactoryTest.php
@@ -50,7 +50,7 @@ class PlaywrightFactoryTest extends TestCase
     public function itCanCreateClientWithCustomLogger(): void
     {
         $logger = new NullLogger();
-        $client = PlaywrightFactory::create(null, $logger);
+        $client = PlaywrightFactory::create(logger: $logger);
 
         $this->assertInstanceOf(PlaywrightClient::class, $client);
     }

--- a/tests/Unit/Browser/BrowserContextDeleteCookieTest.php
+++ b/tests/Unit/Browser/BrowserContextDeleteCookieTest.php
@@ -17,6 +17,7 @@ namespace Playwright\Tests\Unit\Browser;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Playwright\Browser\BrowserContext;
+use Playwright\Configuration\PlaywrightConfig;
 use Playwright\Transport\TransportInterface;
 
 #[CoversClass(BrowserContext::class)]
@@ -71,7 +72,7 @@ final class BrowserContextDeleteCookieTest extends TestCase
             return [];
         });
 
-        $context = new BrowserContext($transport, 'ctx');
+        $context = new BrowserContext($transport, 'ctx', new PlaywrightConfig());
         $context->deleteCookie('foo');
 
         $this->assertTrue($calledAdd, 'context.addCookies should be called to expire matching cookies');

--- a/tests/Unit/Browser/BrowserContextPopupPagesTest.php
+++ b/tests/Unit/Browser/BrowserContextPopupPagesTest.php
@@ -17,6 +17,7 @@ namespace Playwright\Tests\Unit\Browser;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Playwright\Browser\BrowserContext;
+use Playwright\Configuration\PlaywrightConfig;
 use Playwright\Transport\TransportInterface;
 
 #[CoversClass(BrowserContext::class)]
@@ -25,7 +26,7 @@ final class BrowserContextPopupPagesTest extends TestCase
     public function testTracksPopupPagesViaEvents(): void
     {
         $transport = $this->createMock(TransportInterface::class);
-        $context = new BrowserContext($transport, 'ctx1');
+        $context = new BrowserContext($transport, 'ctx1', new PlaywrightConfig());
 
         $this->assertCount(0, $context->pages());
 

--- a/tests/Unit/Page/FramePageTest.php
+++ b/tests/Unit/Page/FramePageTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Playwright\Browser\BrowserContextInterface;
+use Playwright\Configuration\PlaywrightConfig;
 use Playwright\Page\Page;
 use Playwright\Page\PageInterface;
 use Playwright\Transport\TransportInterface;
@@ -37,7 +38,7 @@ class FramePageTest extends TestCase
 
     private function createPage(): PageInterface
     {
-        return new Page($this->transport, $this->context, 'page-1');
+        return new Page($this->transport, $this->context, 'page-1', new PlaywrightConfig());
     }
 
     public function testMainFrame(): void

--- a/tests/Unit/Page/PageEvaluateNormalizerTest.php
+++ b/tests/Unit/Page/PageEvaluateNormalizerTest.php
@@ -17,6 +17,7 @@ namespace Playwright\Tests\Unit\Page;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Playwright\Browser\BrowserContextInterface;
+use Playwright\Configuration\PlaywrightConfig;
 use Playwright\Page\Page;
 use Playwright\Transport\TransportInterface;
 
@@ -37,7 +38,7 @@ final class PageEvaluateNormalizerTest extends TestCase
             }))
             ->willReturn(['result' => 42]);
 
-        $page = new Page($transport, $context, 'p1');
+        $page = new Page($transport, $context, 'p1', new PlaywrightConfig());
         $result = $page->evaluate('return 42;');
         $this->assertSame(42, $result);
     }
@@ -56,7 +57,7 @@ final class PageEvaluateNormalizerTest extends TestCase
             }))
             ->willReturn(['result' => 'Hello']);
 
-        $page = new Page($transport, $context, 'p1');
+        $page = new Page($transport, $context, 'p1', new PlaywrightConfig());
         $result = $page->evaluate('document.title');
         $this->assertSame('Hello', $result);
     }

--- a/tests/Unit/Page/PagePauseTest.php
+++ b/tests/Unit/Page/PagePauseTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Playwright\Browser\BrowserContextInterface;
+use Playwright\Configuration\PlaywrightConfig;
 use Playwright\Page\Page;
 use Playwright\Transport\TransportInterface;
 
@@ -39,7 +40,7 @@ class PagePauseTest extends TestCase
             }))
             ->willReturn(['success' => true]);
 
-        $page = new Page($transport, $context, 'page_1');
+        $page = new Page($transport, $context, 'page_1', new PlaywrightConfig());
         $page->pause();
         $this->assertTrue(true, 'pause() should dispatch page.pause');
     }

--- a/tests/Unit/Page/PagePdfTest.php
+++ b/tests/Unit/Page/PagePdfTest.php
@@ -43,7 +43,7 @@ final class PagePdfTest extends TestCase
             }))
             ->willReturn([]);
 
-        $page = new Page($transport, $context, 'page-unit');
+        $page = new Page($transport, $context, 'page-unit', new PlaywrightConfig());
 
         $result = $page->pdf($expectedPath);
 
@@ -87,7 +87,7 @@ final class PagePdfTest extends TestCase
         $transport = $this->createMock(TransportInterface::class);
         $context = $this->createMock(BrowserContextInterface::class);
 
-        $page = new Page($transport, $context, 'page-unit');
+        $page = new Page($transport, $context, 'page-unit', new PlaywrightConfig());
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Do not provide a "path" option when requesting inline PDF content.');

--- a/tests/Unit/Page/PagePopupTest.php
+++ b/tests/Unit/Page/PagePopupTest.php
@@ -17,6 +17,7 @@ namespace Playwright\Tests\Unit\Page;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Playwright\Browser\BrowserContextInterface;
+use Playwright\Configuration\PlaywrightConfig;
 use Playwright\Exception\TimeoutException;
 use Playwright\Page\Page;
 use Playwright\Transport\TransportInterface;
@@ -32,7 +33,7 @@ final class PagePopupTest extends TestCase
     {
         $this->transport = $this->createMock(TransportInterface::class);
         $this->context = $this->createMock(BrowserContextInterface::class);
-        $this->page = new Page($this->transport, $this->context, 'page1');
+        $this->page = new Page($this->transport, $this->context, 'page1', new PlaywrightConfig());
     }
 
     public function testWaitForPopupSuccess(): void

--- a/tests/Unit/Page/PageRequestTest.php
+++ b/tests/Unit/Page/PageRequestTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Playwright\API\APIRequestContextInterface;
 use Playwright\Browser\BrowserContextInterface;
+use Playwright\Configuration\PlaywrightConfig;
 use Playwright\Page\Page;
 use Playwright\Transport\TransportInterface;
 
@@ -34,7 +35,7 @@ final class PageRequestTest extends TestCase
             ->method('request')
             ->willReturn($api);
 
-        $page = new Page($transport, $context, 'page-1');
+        $page = new Page($transport, $context, 'page-1', new PlaywrightConfig());
 
         $first = $page->request();
         $second = $page->request();

--- a/tests/Unit/Page/PageTest.php
+++ b/tests/Unit/Page/PageTest.php
@@ -17,6 +17,7 @@ namespace Playwright\Tests\Unit\Page;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Playwright\Browser\BrowserContextInterface;
+use Playwright\Configuration\PlaywrightConfig;
 use Playwright\Input\KeyboardInterface;
 use Playwright\Input\MouseInterface;
 use Playwright\Locator\Locator;
@@ -38,7 +39,7 @@ class PageTest extends TestCase
         $context = $this->createMock(BrowserContextInterface::class);
         $pageId = 'page-id';
 
-        $this->page = new Page($this->transport, $context, $pageId);
+        $this->page = new Page($this->transport, $context, $pageId, new PlaywrightConfig());
     }
 
     public function testGetKeyboard(): void

--- a/tests/Unit/PlaywrightFactoryTest.php
+++ b/tests/Unit/PlaywrightFactoryTest.php
@@ -26,25 +26,19 @@ final class PlaywrightFactoryTest extends TestCase
 {
     public function testCreateWithDefaultConfig(): void
     {
-        $factory = new PlaywrightFactory();
-
-        $client = $factory->create();
-
-        $this->assertInstanceOf(PlaywrightClient::class, $client);
+        $this->assertInstanceOf(PlaywrightClient::class, PlaywrightFactory::create());
     }
 
     public function testCreateWithCustomConfig(): void
     {
         $config = new PlaywrightConfig(
             nodePath: '/usr/bin/node',
-            timeoutMs: 60000,
             headless: false,
+            timeoutMs: 60000,
             tracingEnabled: true
         );
 
-        $factory = new PlaywrightFactory();
-
-        $client = $factory->create($config);
+        $client = PlaywrightFactory::create($config);
 
         $this->assertInstanceOf(PlaywrightClient::class, $client);
     }
@@ -52,9 +46,8 @@ final class PlaywrightFactoryTest extends TestCase
     public function testCreateWithLogger(): void
     {
         $logger = $this->createMock(LoggerInterface::class);
-        $factory = new PlaywrightFactory();
 
-        $client = $factory->create(null, $logger);
+        $client = PlaywrightFactory::create(logger: $logger);
 
         $this->assertInstanceOf(PlaywrightClient::class, $client);
     }
@@ -63,15 +56,14 @@ final class PlaywrightFactoryTest extends TestCase
     {
         $config = new PlaywrightConfig(
             nodePath: '/opt/node/bin/node',
-            timeoutMs: 45000,
             headless: true,
+            timeoutMs: 45000,
             tracingEnabled: false
         );
 
         $logger = $this->createMock(LoggerInterface::class);
-        $factory = new PlaywrightFactory();
 
-        $client = $factory->create($config, $logger);
+        $client = PlaywrightFactory::create($config, $logger);
 
         $this->assertInstanceOf(PlaywrightClient::class, $client);
     }


### PR DESCRIPTION
This simplifies the code a little bit and ensures that the same configuration should (you can replace it manually) used around the whole process.