### PR TITLE
ci: use playwright-install --with-deps to fix local execution

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -123,7 +123,7 @@ jobs:
           fi
 
       - name: "Playwright: install browsers"
-        run: php bin/playwright-install --browsers
+        run: php bin/playwright-install --with-deps
 
       - name: "PHPUnit: all tests with coverage"
         run: vendor/bin/phpunit --coverage-clover=coverage.xml


### PR DESCRIPTION
i run the test locally via gh cli
```
gh act pull_request --job integration-tests --matrix php-version:8.2 --matrix dependencies:low
```

i get a error missing shared lib. So i adjust the playwright-install command.