### PR TITLE
bug: implement missing bringToFront function

### DIFF
--- a/bin/lib/handlers.js
+++ b/bin/lib/handlers.js
@@ -235,7 +235,8 @@ class PageHandler extends BaseHandler {
       waitForLoadState: () => page.waitForLoadState(command.state || 'load', command.options),
       frames: () => this.getFrames(page),
       frame: () => this.getFrame(page, command),
-      waitForPopup: () => this.waitForPopup(page, command)
+      waitForPopup: () => this.waitForPopup(page, command),
+      bringToFront: () => page.bringToFront(),
     });
 
     return await ErrorHandler.safeExecute(() => this.executeWithRegistry(registry, method), { method, pageId: command.pageId });


### PR DESCRIPTION
Currentlty the following causes a crash
```
$context = Playwright::chromium(["headless" => false]);
$page = $context->newPage();
$page->bringToFront();
```
This is because bringToFront has not been implemented . 

`$page->bringToFront();` helps to remove focus from address bar towards the page