### PR TITLE
Locator: pass on last exception message

### DIFF
--- a/src/Locator/Locator.php
+++ b/src/Locator/Locator.php
@@ -650,6 +650,7 @@ final class Locator implements \Stringable, LocatorInterface
     {
         $start = microtime(true);
         $timeoutSeconds = $timeoutMs / 1000;
+        $lastExceptionMessage = '';
 
         while ((microtime(true) - $start) < $timeoutSeconds) {
             try {
@@ -657,12 +658,13 @@ final class Locator implements \Stringable, LocatorInterface
                     return;
                 }
             } catch (PlaywrightException $e) {
+                $lastExceptionMessage = $e->getMessage();
             }
 
             usleep(100000);
         }
 
-        throw new TimeoutException(sprintf('%s (timeout: %dms)', $message, $timeoutMs));
+        throw new TimeoutException(sprintf('%s (timeout: %dms): %s', $message, $timeoutMs, $lastExceptionMessage));
     }
 
     /**


### PR DESCRIPTION
Currently, the exception thrown in Locator is not very informative. Having a hint of why the failure occurred would help debugging.

All of the information I needed was in the original exception which led to the timeout, so I think it makes sense to pass on this message instead of hiding it.