### PR TITLE
Support PSR Log 2.0 in addition to 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "require": {
         "php": "^8.2",
         "psr/clock": "^1.0",
-        "psr/log": "^3.0",
+        "psr/log": "^2.0 || ^3.0",
         "symfony/console": "^6.4 || ^7.3 || ^8.0",
         "symfony/process": "^6.4 || ^7.3 || ^8.0"
     },


### PR DESCRIPTION
Hello 👋🏼,

Despite Sylius 1.x cames EOL we still have clients that are using it. I would love to introduce Playwright PHP to our Behat scenarios, but Sylius enforces PSR log v2. From what I saw, a lot of packages supports version 1-3 or 2-3, so it'd be lovely if we can add a lower version support as it brings no additional work to maintain it.