### PR TITLE
Add withExecutablePath() to BrowserBuilder

### DIFF
--- a/src/Browser/BrowserBuilder.php
+++ b/src/Browser/BrowserBuilder.php
@@ -48,6 +48,13 @@ final class BrowserBuilder
         return $this;
     }
 
+    public function withExecutablePath(string $executablePath): self
+    {
+        $this->launchOptions['executablePath'] = $executablePath;
+
+        return $this;
+    }
+
     /**
      * @param array<string> $args
      */


### PR DESCRIPTION
The underlying transport already forwards launchOptions as-is, but there was no builder method to set executablePath, so there was no way to point launch() at a custom browser build. This adds withExecutablePath(), mirroring withSlowMo(). Motivated by invisible_playwright, a Playwright wrapper around a Firefox build patched at the source level for a realistic fingerprint. Opened as draft, happy to add a test if that's expected here.