### PR TITLE
Fix ProcessJsonRpcClient never clearing the Process output buffers

### DIFF
--- a/src/Transport/JsonRpc/ProcessJsonRpcClient.php
+++ b/src/Transport/JsonRpc/ProcessJsonRpcClient.php
@@ -124,11 +124,13 @@ final class ProcessJsonRpcClient extends JsonRpcClient implements JsonRpcClientI
     private function readProcessOutput(): void
     {
         $stdout = $this->process->getIncrementalOutput();
+        $this->process->clearOutput();
         if ('' !== $stdout) {
             $this->outputBuffer .= $stdout;
         }
 
         $stderr = $this->process->getIncrementalErrorOutput();
+        $this->process->clearErrorOutput();
         if ('' !== $stderr) {
             $this->logger->warning('Process stderr', ['stderr' => $stderr]);
         }

--- a/tests/Unit/Transport/JsonRpc/ProcessJsonRpcClientTest.php
+++ b/tests/Unit/Transport/JsonRpc/ProcessJsonRpcClientTest.php
@@ -144,4 +144,56 @@ final class ProcessJsonRpcClientTest extends TestCase
 
         $client->send('test.method');
     }
+
+    public function testReadProcessOutputClearsBothProcessBuffers(): void
+    {
+        $mockProcess = $this->createMock(Process::class);
+        $mockProcessLauncher = $this->createMock(ProcessLauncherInterface::class);
+
+        $mockProcess->method('isRunning')->willReturn(true);
+        $mockProcess->method('getPid')->willReturn(12345);
+        $mockProcess->method('getIncrementalOutput')->willReturn('');
+        $mockProcess->method('getIncrementalErrorOutput')->willReturn('');
+        $mockProcess->expects($this->once())->method('clearOutput');
+        $mockProcess->expects($this->once())->method('clearErrorOutput');
+        $mockProcessLauncher->method('getInputStream')->willReturn($this->mockInputStream);
+        $mockProcessLauncher->method('ensureRunning');
+
+        $client = new ProcessJsonRpcClient(
+            process: $mockProcess,
+            processLauncher: $mockProcessLauncher,
+            clock: $this->clock,
+            logger: $this->logger
+        );
+
+        $readProcessOutput = new \ReflectionMethod($client, 'readProcessOutput');
+        $readProcessOutput->invoke($client);
+    }
+
+    public function testReadProcessOutputClearsBuffersAcrossMultiplePolls(): void
+    {
+        $mockProcess = $this->createMock(Process::class);
+        $mockProcessLauncher = $this->createMock(ProcessLauncherInterface::class);
+
+        $mockProcess->method('isRunning')->willReturn(true);
+        $mockProcess->method('getPid')->willReturn(12345);
+        $mockProcess->method('getIncrementalOutput')->willReturn('');
+        $mockProcess->method('getIncrementalErrorOutput')->willReturn('');
+        $mockProcess->expects($this->exactly(3))->method('clearOutput');
+        $mockProcess->expects($this->exactly(3))->method('clearErrorOutput');
+        $mockProcessLauncher->method('getInputStream')->willReturn($this->mockInputStream);
+        $mockProcessLauncher->method('ensureRunning');
+
+        $client = new ProcessJsonRpcClient(
+            process: $mockProcess,
+            processLauncher: $mockProcessLauncher,
+            clock: $this->clock,
+            logger: $this->logger
+        );
+
+        $readProcessOutput = new \ReflectionMethod($client, 'readProcessOutput');
+        $readProcessOutput->invoke($client);
+        $readProcessOutput->invoke($client);
+        $readProcessOutput->invoke($client);
+    }
 }


### PR DESCRIPTION
Fixes #102

`ProcessJsonRpcClient::readProcessOutput()` read newly produced bytes from the Node bridge process with `Process::getIncrementalOutput()` / `getIncrementalErrorOutput()`, but never called the matching `Process::clearOutput()` / `clearErrorOutput()`. Symfony's `Process` keeps the entire stdout/stderr history in an internal buffer (a php://temp stream that spills to a disk-backed temp file past a small in-memory threshold) for as long as the process object is alive — the incremental getters only track a read cursor, they do not discard what was already consumed.

On a long-lived session (a multi-hour Behat regression run, for example) every JSON-RPC response — page HTML, base64 screenshots, ARIA snapshots — accumulated forever in that buffer. Once the temp file grew large enough to fill the available disk space, `Process::addOutput()` started silently failing to write further bytes, and every subsequent request in `waitForResponse()` spun until its deadline and failed with the generic `JSON-RPC request N timed out` — indistinguishable from a slow browser action or a genuine hang.

Fixes it by calling `clearOutput()`/`clearErrorOutput()` right after each incremental read, so the Process buffers stay empty; nothing else reads the accumulated (non-incremental) output.

## Testing

- Added two unit tests on `ProcessJsonRpcClient` (`testReadProcessOutputClearsBothProcessBuffers`, `testReadProcessOutputClearsBuffersAcrossMultiplePolls`) asserting `clearOutput()`/`clearErrorOutput()` are called once per poll — verified both fail against the pre-fix code (0 calls observed) and pass with the fix.
- Full unit suite: 798/798 passing (2 pre-existing, unrelated deprecation warnings elsewhere).
- `php-cs-fixer --dry-run` clean; `phpstan analyse` (level 10) reports 0 errors on the changed files.

Discovered while running the OroCommerce Behat regression suite on this driver: several nodes started failing late in the run with unexplained `JSON-RPC request N timed out` errors, traced back to full CI-node disks.