### PR TITLE
Fix LspFraming permanently poisoning the stream on stray non-LSP output

### DIFF
--- a/src/Transport/JsonRpc/LspFraming.php
+++ b/src/Transport/JsonRpc/LspFraming.php
@@ -62,7 +62,13 @@ final class LspFraming
 
         $contentLength = self::parseContentLength($headers);
         if (null === $contentLength) {
-            throw new \InvalidArgumentException('Missing or invalid Content-Length header');
+            // resync: skip stray non-LSP output (e.g. browser crash spew) up to the next frame
+            $resyncPos = strpos($buffer, 'Content-Length:', 1);
+            if (false === $resyncPos) {
+                return null;
+            }
+
+            return self::extractOneMessage(substr($buffer, $resyncPos));
         }
 
         if (strlen($buffer) < $contentStart + $contentLength) {

--- a/tests/Unit/Transport/JsonRpc/LspFramingTest.php
+++ b/tests/Unit/Transport/JsonRpc/LspFramingTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the community-maintained Playwright PHP project.
+ * It is not affiliated with or endorsed by Microsoft.
+ *
+ * (c) 2025-Present - Playwright PHP - https://github.com/playwright-php
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Playwright\Tests\Unit\Transport\JsonRpc;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Playwright\Transport\JsonRpc\LspFraming;
+
+#[CoversClass(LspFraming::class)]
+final class LspFramingTest extends TestCase
+{
+    public function testDecodesASingleWellFormedMessage(): void
+    {
+        $decoded = LspFraming::decode(LspFraming::encode('{"ok":1}'));
+
+        $this->assertSame(['{"ok":1}'], $decoded['messages']);
+        $this->assertSame('', $decoded['remainingBuffer']);
+    }
+
+    public function testDecodesMultipleConsecutiveMessages(): void
+    {
+        $buffer = LspFraming::encode('{"ok":1}').LspFraming::encode('{"ok":2}');
+
+        $decoded = LspFraming::decode($buffer);
+
+        $this->assertSame(['{"ok":1}', '{"ok":2}'], $decoded['messages']);
+    }
+
+    public function testBuffersAnIncompleteMessageInsteadOfFailing(): void
+    {
+        $partial = substr(LspFraming::encode('{"ok":1}'), 0, -3);
+
+        $decoded = LspFraming::decode($partial);
+
+        $this->assertSame([], $decoded['messages']);
+        $this->assertSame($partial, $decoded['remainingBuffer']);
+    }
+
+    public function testResyncsPastStrayNonLspOutputInsteadOfThrowing(): void
+    {
+        $frame1 = LspFraming::encode('{"ok":1}');
+        $frame2 = LspFraming::encode('{"ok":2}');
+        $polluted = "crash spew\nstack line\n".$frame1.'garbage'.$frame2;
+
+        $decoded = LspFraming::decode($polluted);
+
+        $this->assertSame(['{"ok":1}', '{"ok":2}'], $decoded['messages']);
+    }
+
+    public function testBuffersPureGarbageWithNoContentLengthMarkerAtAll(): void
+    {
+        $decoded = LspFraming::decode("this is not a frame at all\r\n\r\n");
+
+        $this->assertSame([], $decoded['messages']);
+    }
+
+    public function testMalformedContentLengthValueIsSkippedRatherThanThrown(): void
+    {
+        $frame = LspFraming::encode('{"ok":1}');
+        $polluted = "Content-Length: not-a-number\r\n\r\n".$frame;
+
+        $decoded = LspFraming::decode($polluted);
+
+        $this->assertSame(['{"ok":1}'], $decoded['messages']);
+    }
+}


### PR DESCRIPTION
Fixes #105

`LspFraming::extractOneMessage()` threw `InvalidArgumentException('Missing or invalid Content-Length header')` as soon as the receive buffer did not start with a valid frame header, and never resynced afterwards. Any stray output on the Node bridge stdout — a Chromium crash dump, a stray `console.log` from a dependency, anything writing to fd 1 — permanently poisoned the framed stream: every subsequent `sendAndReceive()` on that client threw, with no way to recover the session.

Fixes it by resyncing instead of throwing: when the current header block does not contain a valid `Content-Length`, skip forward to the next `Content-Length:` occurrence in the buffer and retry from there; if none is found yet, keep buffering. This is the same skip-to-next-header strategy LSP-based tooling (e.g. vscode-languageclient) uses for robustness against interleaved non-protocol output.

## Testing

- Added `tests/Unit/Transport/JsonRpc/LspFramingTest.php` (6 tests): normal single/multiple message decoding, buffering an incomplete message, resyncing past stray text before/between well-formed frames, buffering pure garbage with no `Content-Length:` marker at all, and skipping a malformed `Content-Length` value. Verified 3 of the 6 fail with the original `InvalidArgumentException` against the pre-fix code and all 6 pass with the fix.
- Full test suite: 802/802 unit, 236/236 integration passing (2 pre-existing, unrelated deprecation warnings elsewhere).
- `php-cs-fixer --dry-run` clean; `phpstan analyse` (level 10) reports 0 errors on the changed/added files.

Discovered while running the OroCommerce Behat regression suite on a driver built on top of this library: after a Chromium renderer crash, crash diagnostics ended up interleaved with the framed stream and every following scenario in that process failed with the same `InvalidArgumentException`, losing the rest of the run on that node.