### PR TITLE
Align interfaces with the shipped public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## [Unreleased]
+
+### Added
+- Interface annotations (`@method`, no BC impact) for methods already shipped by the
+  concrete classes: `BrowserContext::clock()`, `BrowserContext::setGeolocation()`,
+  `BrowserContext::setOffline()`, `Dialog::page()`, `Keyboard::insertText()`,
+  `Page::pause()`, `Response::headerValue()`. They will move to real interface
+  declarations in the next major.
+
 ## [1.1.0] - 2025-12-23
 
 ### Added

--- a/src/Browser/BrowserContextInterface.php
+++ b/src/Browser/BrowserContextInterface.php
@@ -15,9 +15,15 @@ declare(strict_types=1);
 namespace Playwright\Browser;
 
 use Playwright\API\APIRequestContextInterface;
+use Playwright\Clock\ClockInterface;
 use Playwright\Network\NetworkThrottling;
 use Playwright\Page\PageInterface;
 
+/**
+ * @method ClockInterface clock()                                                                   The context's clock, to fake and advance time
+ * @method void           setGeolocation(?float $latitude, ?float $longitude, ?float $accuracy = 0) Sets the context's geolocation; null coordinates clear it
+ * @method void           setOffline(bool $offline)                                                 Toggles the context's network offline or back online
+ */
 interface BrowserContextInterface
 {
     /**

--- a/src/Dialog/DialogInterface.php
+++ b/src/Dialog/DialogInterface.php
@@ -14,8 +14,12 @@ declare(strict_types=1);
 
 namespace Playwright\Dialog;
 
+use Playwright\Page\PageInterface;
+
 /**
  * @author Simon André <smn.andre@gmail.com>
+ *
+ * @method PageInterface page() The page that opened the dialog
  */
 interface DialogInterface
 {

--- a/src/Input/KeyboardInterface.php
+++ b/src/Input/KeyboardInterface.php
@@ -14,6 +14,9 @@ declare(strict_types=1);
 
 namespace Playwright\Input;
 
+/**
+ * @method void insertText(string $text) Inserts the text as-is: only an input event fires, no keydown/keyup
+ */
 interface KeyboardInterface
 {
     public function down(string $key): void;

--- a/src/Network/ResponseInterface.php
+++ b/src/Network/ResponseInterface.php
@@ -16,6 +16,9 @@ namespace Playwright\Network;
 
 use Playwright\Frame\FrameInterface;
 
+/**
+ * @method ?string headerValue(string $name) The first value of the header, or null when the header is absent
+ */
 interface ResponseInterface
 {
     public function url(): string;

--- a/src/Page/PageInterface.php
+++ b/src/Page/PageInterface.php
@@ -43,6 +43,9 @@ use Playwright\Page\Options\WaitForSelectorOptions;
 use Playwright\Page\Options\WaitForUrlOptions;
 use Playwright\Regex;
 
+/**
+ * @method $this pause() Opens Playwright Inspector and pauses script execution
+ */
 interface PageInterface
 {
     /**


### PR DESCRIPTION
Seven public methods live on the concrete classes without being part of their interface contract. 

Declaring them for real would break any hand-written implementation, so they land as @method annotations.

Changelog documents the intent.