### PR TITLE
Register page default timeout actions server-side (fix #94)

### DIFF
--- a/bin/lib/handlers.js
+++ b/bin/lib/handlers.js
@@ -220,6 +220,8 @@ class PageHandler extends BaseHandler {
       title: () => PromiseUtils.wrapValue(page.title()),
       setViewportSize: () => page.setViewportSize(command.size),
       viewportSize: () => this.createValueResult(page.viewportSize()),
+      setDefaultTimeout: () => page.setDefaultTimeout(command.timeout),
+      setDefaultNavigationTimeout: () => page.setDefaultNavigationTimeout(command.timeout),
       waitForURL: () => page.waitForURL(command.url, command.options),
       waitForSelector: () => page.waitForSelector(command.selector, command.options),
       waitForFunction: () => this.waitForFunction(page, command),

--- a/tests/Functional/Browser/PageTimeoutTest.php
+++ b/tests/Functional/Browser/PageTimeoutTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the community-maintained Playwright PHP project.
+ * It is not affiliated with or endorsed by Microsoft.
+ *
+ * (c) 2025-Present - Playwright PHP - https://github.com/playwright-php
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Playwright\Tests\Functional\Browser;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use Playwright\Exception\TimeoutException;
+use Playwright\Page\Page;
+use Playwright\Tests\Functional\FunctionalTestCase;
+
+#[CoversClass(Page::class)]
+final class PageTimeoutTest extends FunctionalTestCase
+{
+    public function testSetDefaultTimeoutAppliesToWaits(): void
+    {
+        $this->goto('/index.html');
+
+        $this->page->setDefaultTimeout(500);
+
+        $start = microtime(true);
+
+        try {
+            $this->page->waitForSelector('#does-not-exist');
+            self::fail('Expected a TimeoutException');
+        } catch (TimeoutException) {
+        }
+
+        $elapsed = microtime(true) - $start;
+        self::assertLessThan(10.0, $elapsed, 'The 500ms default timeout should apply instead of the 30s built-in default');
+    }
+
+    public function testSetDefaultNavigationTimeoutIsAccepted(): void
+    {
+        $this->goto('/index.html');
+
+        $result = $this->page->setDefaultNavigationTimeout(10000);
+
+        self::assertSame($this->page, $result);
+    }
+}

--- a/tests/Unit/Page/PageTest.php
+++ b/tests/Unit/Page/PageTest.php
@@ -498,4 +498,34 @@ class PageTest extends TestCase
         $result = $this->page->reload();
         $this->assertSame($this->page, $result);
     }
+
+    public function testSetDefaultTimeoutSendsCommandAndReturnsSelf(): void
+    {
+        $this->transport->expects($this->once())
+            ->method('send')
+            ->with([
+                'timeout' => 500,
+                'action' => 'page.setDefaultTimeout',
+                'pageId' => 'page-id',
+            ])
+            ->willReturn([]);
+
+        $result = $this->page->setDefaultTimeout(500);
+        $this->assertSame($this->page, $result);
+    }
+
+    public function testSetDefaultNavigationTimeoutSendsCommandAndReturnsSelf(): void
+    {
+        $this->transport->expects($this->once())
+            ->method('send')
+            ->with([
+                'timeout' => 10000,
+                'action' => 'page.setDefaultNavigationTimeout',
+                'pageId' => 'page-id',
+            ])
+            ->willReturn([]);
+
+        $result = $this->page->setDefaultNavigationTimeout(10000);
+        $this->assertSame($this->page, $result);
+    }
 }


### PR DESCRIPTION
The PHP client sends `page.setDefaultTimeout` and `page.setDefaultNavigationTimeout`, but the Node server had no matching entries in the PageHandler registry, so both calls failed with "Unknown action". 

Fixes #94