### PR TITLE
Send unroute to the page instead of the context (fix #96)

### DIFF
--- a/bin/lib/handlers.js
+++ b/bin/lib/handlers.js
@@ -232,6 +232,7 @@ class PageHandler extends BaseHandler {
       addStyleTag: () => page.addStyleTag(command.options).then(() => ({ success: true })),
       handleDialog: () => this.handleDialog(command),
       route: () => RouteUtils.setupRoute(page, command.pageId, command.url, this.generateId, this.routes, this.extractRequestData, this.sendFramedResponse, () => `route_${++this.routeCounter.value}`),
+      unroute: () => page.unroute(command.url),
       goBack: () => page.goBack(command.options),
       goForward: () => page.goForward(command.options),
       reload: () => page.reload(command.options),

--- a/src/Page/Page.php
+++ b/src/Page/Page.php
@@ -951,7 +951,7 @@ final class Page implements PageInterface, EventDispatcherInterface
 
     public function unroute(string $url, ?callable $handler = null): void
     {
-        $this->context->unroute($url, $handler);
+        $this->sendCommand('unroute', ['url' => $url]);
     }
 
     public function handleDialog(string $dialogId, bool $accept, ?string $promptText = null): void

--- a/tests/Functional/Network/RouteTest.php
+++ b/tests/Functional/Network/RouteTest.php
@@ -107,14 +107,23 @@ final class RouteTest extends FunctionalTestCase
         $handler = function ($route) {
             $route->fulfill([
                 'status' => 200,
-                'contentType' => 'text/plain',
-                'body' => 'Intercepted',
+                'contentType' => 'application/json',
+                'body' => \json_encode(['message' => 'Intercepted']),
             ]);
         };
 
-        $this->page->route('**/api/text', $handler);
-        $this->page->unroute('**/api/text', $handler);
+        $this->page->route('**/api/data.json', $handler);
 
-        self::assertTrue(true);
+        $this->page->click('#fetch-json');
+        $this->page->waitForSelector('#fetch-result:has-text("Intercepted")', ['timeout' => 5000]);
+
+        $this->page->unroute('**/api/data.json', $handler);
+
+        // Without the route, /api/data.json 404s and the page reports an error
+        $this->page->click('#fetch-json');
+        $this->page->waitForSelector('#fetch-result:has-text("Error")', ['timeout' => 5000]);
+
+        $result = $this->page->locator('#fetch-result')->textContent();
+        self::assertStringContainsString('Error', $result);
     }
 }

--- a/tests/Unit/Page/PageTest.php
+++ b/tests/Unit/Page/PageTest.php
@@ -528,4 +528,24 @@ class PageTest extends TestCase
         $result = $this->page->setDefaultNavigationTimeout(10000);
         $this->assertSame($this->page, $result);
     }
+
+    public function testUnrouteSendsPageCommand(): void
+    {
+        $transport = $this->createMock(TransportInterface::class);
+        $context = $this->createMock(BrowserContextInterface::class);
+        $page = new Page($transport, $context, 'page-id', new PlaywrightConfig());
+
+        $context->expects($this->never())
+            ->method('unroute');
+        $transport->expects($this->once())
+            ->method('send')
+            ->with([
+                'url' => '**/api/**',
+                'action' => 'page.unroute',
+                'pageId' => 'page-id',
+            ])
+            ->willReturn([]);
+
+        $page->unroute('**/api/**');
+    }
 }


### PR DESCRIPTION
`Page::unroute()` delegated to `BrowserContext::unroute()`, a no-op because the route is registered on the page object server-side. 

Send `page.unroute` and handle it in the PageHandler registry. 

Fixes #96