### PR TITLE
Unify tracing on PW_TRACE and wire config tracing (fix #79)

### DIFF
--- a/docs/guide/testing-with-phpunit.md
+++ b/docs/guide/testing-with-phpunit.md
@@ -92,7 +92,11 @@ When a test fails, the library automatically provides tools to help you debug:
 
 * **Screenshots:** A screenshot of the page at the moment of failure is automatically saved to a `test-failures`
   directory in your project root.
-* **Tracing:** You can enable tracing by setting the `PW_TRACE` environment variable. When a test fails with tracing
-  enabled, a `trace.zip` file is generated. You can drag and drop this file into
-  the [Playwright Trace Viewer](https://playwright.dev/docs/trace-viewer) to see a complete, time-traveling recording of
-  your test's execution.
+* **Tracing:** You can enable tracing by setting the `PW_TRACE` environment variable (`PW_TRACE=1`). When a test fails
+  with tracing enabled, a trace archive named after the test is saved next to the screenshot in `test-failures/`. You
+  can drag and drop this file into the [Playwright Trace Viewer](https://playwright.dev/docs/trace-viewer) to see a
+  complete, time-traveling recording of your test's execution.
+
+`PW_TRACE` is the single switch for tracing. It is also read by `PlaywrightConfigBuilder::fromEnv()`: every browser
+context created from that configuration records a trace, saved to `PW_TRACE_DIR` (default: `traces/` in the working
+directory) when the context closes.

--- a/src/Browser/BrowserContext.php
+++ b/src/Browser/BrowserContext.php
@@ -53,6 +53,8 @@ final class BrowserContext implements BrowserContextInterface, EventDispatcherIn
 
     private ClockInterface $clock;
 
+    private bool $autoTracing = false;
+
     public function __construct(
         private readonly TransportInterface $transport,
         private readonly string $contextId,
@@ -63,6 +65,18 @@ final class BrowserContext implements BrowserContextInterface, EventDispatcherIn
         }
 
         $this->clock = new Clock($this->transport, $this->contextId);
+
+        if ($this->config->tracingEnabled) {
+            $this->transport->send([
+                'action' => 'context.startTracing',
+                'contextId' => $this->contextId,
+                'options' => [
+                    'screenshots' => $this->config->traceScreenshots,
+                    'snapshots' => $this->config->traceSnapshots,
+                ],
+            ]);
+            $this->autoTracing = true;
+        }
     }
 
     public function clock(): ClockInterface
@@ -193,10 +207,29 @@ final class BrowserContext implements BrowserContextInterface, EventDispatcherIn
 
     public function close(): void
     {
+        if ($this->autoTracing) {
+            $this->saveAutoTrace();
+        }
+
         $this->transport->send([
             'action' => 'context.close',
             'contextId' => $this->contextId,
         ]);
+    }
+
+    private function saveAutoTrace(): void
+    {
+        $dir = $this->config->traceDir ?? getcwd().'/traces';
+        if (!is_dir($dir) && !@mkdir($dir, 0777, true) && !is_dir($dir)) {
+            throw new \RuntimeException(sprintf('Trace directory "%s" was not created', $dir));
+        }
+
+        $this->transport->send([
+            'action' => 'context.stopTracing',
+            'contextId' => $this->contextId,
+            'path' => $dir.'/trace-'.$this->contextId.'.zip',
+        ]);
+        $this->autoTracing = false;
     }
 
     /**
@@ -465,6 +498,11 @@ final class BrowserContext implements BrowserContextInterface, EventDispatcherIn
      */
     public function startTracing(PageInterface $page, array $options = []): void
     {
+        if ($this->autoTracing) {
+            // Tracing already runs for the whole context (config-enabled)
+            return;
+        }
+
         $this->transport->send([
             'action' => 'context.startTracing',
             'contextId' => $this->contextId,
@@ -494,6 +532,7 @@ final class BrowserContext implements BrowserContextInterface, EventDispatcherIn
             'pageId' => $page->getPageIdForTransport(),
             'path' => $path,
         ]);
+        $this->autoTracing = false;
     }
 
     public function setNetworkThrottling(NetworkThrottling $throttling): void

--- a/src/Configuration/PlaywrightConfigBuilder.php
+++ b/src/Configuration/PlaywrightConfigBuilder.php
@@ -115,7 +115,7 @@ final class PlaywrightConfigBuilder
             $b->withSlowMoMs((int) $slow);
         }
 
-        if (($trace = $get('PW_TRACING')) !== null) {
+        if (($trace = $get('PW_TRACE')) !== null) {
             $b->withTracing(self::strToBool($trace), $get('PW_TRACE_DIR') ?: null);
         }
 

--- a/tests/Functional/Tracing/AutoTracingTest.php
+++ b/tests/Functional/Tracing/AutoTracingTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the community-maintained Playwright PHP project.
+ * It is not affiliated with or endorsed by Microsoft.
+ *
+ * (c) 2025-Present - Playwright PHP - https://github.com/playwright-php
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Playwright\Tests\Functional\Tracing;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use Playwright\Browser\BrowserContext;
+use Playwright\Configuration\PlaywrightConfig;
+use Playwright\PlaywrightFactory;
+use Playwright\Tests\Functional\FunctionalTestCase;
+use Symfony\Component\Process\ExecutableFinder;
+
+#[CoversClass(BrowserContext::class)]
+final class AutoTracingTest extends FunctionalTestCase
+{
+    public function testTraceIsSavedOnCloseWhenConfigEnablesTracing(): void
+    {
+        $node = (new ExecutableFinder())->find('node');
+        if (null === $node) {
+            self::markTestSkipped('Node.js executable not found.');
+        }
+
+        $traceDir = sys_get_temp_dir().'/pw-php-auto-trace-'.uniqid();
+
+        $config = new PlaywrightConfig(
+            nodePath: $node,
+            tracingEnabled: true,
+            traceDir: $traceDir,
+            traceScreenshots: true,
+            traceSnapshots: true,
+        );
+
+        $playwright = PlaywrightFactory::create($config);
+        $browser = $playwright->chromium()->launch();
+
+        try {
+            $context = $browser->newContext();
+            $page = $context->newPage();
+            $page->goto($this->getBaseUrl().'/index.html');
+
+            $context->close();
+
+            $traces = glob($traceDir.'/trace-*.zip') ?: [];
+            self::assertCount(1, $traces);
+            self::assertGreaterThan(0, (int) filesize($traces[0]));
+        } finally {
+            $browser->close();
+
+            foreach (glob($traceDir.'/*.zip') ?: [] as $file) {
+                @unlink($file);
+            }
+            if (is_dir($traceDir)) {
+                @rmdir($traceDir);
+            }
+        }
+    }
+}

--- a/tests/Unit/Browser/BrowserContextTest.php
+++ b/tests/Unit/Browser/BrowserContextTest.php
@@ -429,4 +429,122 @@ final class BrowserContextTest extends TestCase
 
         $this->context->disableNetworkThrottling();
     }
+
+    /**
+     * @param list<array<string, mixed>> $sent
+     */
+    private function createRecordingTransport(array &$sent): TransportInterface
+    {
+        $transport = $this->createMock(TransportInterface::class);
+        $transport->method('send')->willReturnCallback(static function (array $payload) use (&$sent): array {
+            $sent[] = $payload;
+
+            return [];
+        });
+
+        return $transport;
+    }
+
+    public function testAutoTracingStartsWhenConfigEnablesTracing(): void
+    {
+        $sent = [];
+        $transport = $this->createRecordingTransport($sent);
+
+        new BrowserContext($transport, 'ctx_trace', new PlaywrightConfig(
+            tracingEnabled: true,
+            traceScreenshots: true,
+            traceSnapshots: true,
+        ));
+
+        $this->assertSame([[
+            'action' => 'context.startTracing',
+            'contextId' => 'ctx_trace',
+            'options' => ['screenshots' => true, 'snapshots' => true],
+        ]], $sent);
+    }
+
+    public function testCloseSavesTheAutoTrace(): void
+    {
+        $traceDir = sys_get_temp_dir().'/pw-php-auto-trace-'.uniqid();
+        $sent = [];
+        $transport = $this->createRecordingTransport($sent);
+
+        $context = new BrowserContext($transport, 'ctx_trace', new PlaywrightConfig(
+            tracingEnabled: true,
+            traceDir: $traceDir,
+        ));
+
+        try {
+            $context->close();
+
+            $actions = array_column($sent, 'action');
+            $this->assertSame(['context.startTracing', 'context.stopTracing', 'context.close'], $actions);
+            $this->assertSame($traceDir.'/trace-ctx_trace.zip', $sent[1]['path']);
+        } finally {
+            if (is_dir($traceDir)) {
+                rmdir($traceDir);
+            }
+        }
+    }
+
+    public function testCloseThrowsWhenTheTraceDirectoryCannotBeCreated(): void
+    {
+        // A regular file as the parent makes the recursive mkdir fail whatever the permissions are.
+        $blocker = (string) tempnam(sys_get_temp_dir(), 'pw-php-auto-trace-blocker');
+        $traceDir = $blocker.'/traces';
+
+        $sent = [];
+        $transport = $this->createRecordingTransport($sent);
+
+        $context = new BrowserContext($transport, 'ctx_trace', new PlaywrightConfig(
+            tracingEnabled: true,
+            traceDir: $traceDir,
+        ));
+
+        $thrown = null;
+
+        try {
+            $context->close();
+        } catch (\RuntimeException $e) {
+            $thrown = $e;
+        } finally {
+            unlink($blocker);
+        }
+
+        $this->assertInstanceOf(\RuntimeException::class, $thrown);
+        $this->assertSame(sprintf('Trace directory "%s" was not created', $traceDir), $thrown->getMessage());
+        $this->assertSame(['context.startTracing'], array_column($sent, 'action'));
+    }
+
+    public function testStartTracingIsNoOpWhenAutoTracingIsActive(): void
+    {
+        $sent = [];
+        $transport = $this->createRecordingTransport($sent);
+
+        $context = new BrowserContext($transport, 'ctx_trace', new PlaywrightConfig(tracingEnabled: true));
+
+        $page = $this->createMock(PageInterface::class);
+        $context->startTracing($page, ['screenshots' => true, 'snapshots' => true]);
+
+        $this->assertCount(1, $sent);
+        $this->assertSame('context.startTracing', $sent[0]['action']);
+    }
+
+    public function testManualStopTracingConsumesTheAutoTrace(): void
+    {
+        $sent = [];
+        $transport = $this->createRecordingTransport($sent);
+
+        $context = new BrowserContext($transport, 'ctx_trace', new PlaywrightConfig(tracingEnabled: true));
+
+        $page = $this->createMock(PageInterface::class);
+        $page->method('getPageIdForTransport')->willReturn('page_1');
+
+        $context->stopTracing($page, '/tmp/manual-trace.zip');
+        $context->close();
+
+        $actions = array_column($sent, 'action');
+        $this->assertSame(['context.startTracing', 'context.stopTracing', 'context.close'], $actions);
+        $this->assertSame('/tmp/manual-trace.zip', $sent[1]['path']);
+    }
 }

--- a/tests/Unit/Configuration/PlaywrightConfigBuilderTest.php
+++ b/tests/Unit/Configuration/PlaywrightConfigBuilderTest.php
@@ -35,6 +35,7 @@ class PlaywrightConfigBuilderTest extends TestCase
             'PW_HEADLESS',
             'PW_TIMEOUT_MS',
             'PW_SLOWMO_MS',
+            'PW_TRACE',
             'PW_TRACING',
             'PW_TRACE_DIR',
             'PW_DOWNLOADS_DIR',
@@ -241,7 +242,7 @@ class PlaywrightConfigBuilderTest extends TestCase
         putenv('PW_HEADLESS=false');
         putenv('PW_TIMEOUT_MS=60000');
         putenv('PW_SLOWMO_MS=500');
-        putenv('PW_TRACING=true');
+        putenv('PW_TRACE=true');
         putenv('PW_TRACE_DIR=/env/traces');
         putenv('PW_DOWNLOADS_DIR=/env/downloads');
         putenv('PW_VIDEOS_DIR=/env/videos');
@@ -353,5 +354,27 @@ class PlaywrightConfigBuilderTest extends TestCase
         $this->assertEquals(BrowserType::WEBKIT, $config->browser);
         $this->assertTrue($config->headless);
         $this->assertEquals(45000, $config->timeoutMs);
+    }
+
+    #[Test]
+    public function itReadsTracingFromPwTraceEnv(): void
+    {
+        putenv('PW_TRACE=true');
+        putenv('PW_TRACE_DIR=/env/traces');
+
+        $config = PlaywrightConfigBuilder::fromEnv()->build();
+
+        $this->assertTrue($config->tracingEnabled);
+        $this->assertEquals('/env/traces', $config->traceDir);
+    }
+
+    #[Test]
+    public function itIgnoresTheRemovedPwTracingVariable(): void
+    {
+        putenv('PW_TRACING=true');
+
+        $config = PlaywrightConfigBuilder::fromEnv()->build();
+
+        $this->assertFalse($config->tracingEnabled);
     }
 }


### PR DESCRIPTION
`PW_TRACE` and `PW_TRACING` coexisted: the PHPUnit trait read `PW_TRACE` while `PlaywrightConfigBuilder::fromEnv()` read `PW_TRACING`, and the tracingEnabled/traceDir config fields were never consumed at runtime. 

`fromEnv()` now reads `PW_TRACE` only: `PW_TRACING` is removed since it never had any runtime effect. 

Config tracing is wired: contexts start tracing on creation and save the trace to traceDir on close. 

Fixes #79