### PR TITLE
Register context.setStorageState on the server (fix #98)

### DIFF
--- a/bin/lib/handlers.js
+++ b/bin/lib/handlers.js
@@ -39,6 +39,7 @@ class ContextHandler extends BaseHandler {
       unroute: () => context.unroute(command.url),
       cookies: async () => ({ cookies: await context.cookies(command.urls) }),
       storageState: async () => ({ storageState: await context.storageState(command.options) }),
+      setStorageState: () => context.setStorageState(command.storageState),
       clipboardText: () => this.getClipboardText(context),
       close: () => this.closeContext(context, command.contextId),
       newPage: () => this.createNewPage(context, command)

--- a/tests/Functional/Auth/StorageStateTest.php
+++ b/tests/Functional/Auth/StorageStateTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the community-maintained Playwright PHP project.
+ * It is not affiliated with or endorsed by Microsoft.
+ *
+ * (c) 2025-Present - Playwright PHP - https://github.com/playwright-php
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Playwright\Tests\Functional\Auth;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use Playwright\Browser\BrowserContext;
+use Playwright\Browser\StorageState;
+use Playwright\Tests\Functional\FunctionalTestCase;
+
+#[CoversClass(BrowserContext::class)]
+#[CoversClass(StorageState::class)]
+final class StorageStateTest extends FunctionalTestCase
+{
+    public function testCanSetStorageStateOnExistingContext(): void
+    {
+        $storageState = StorageState::fromArray([
+            'cookies' => [[
+                'name' => 'auth_token',
+                'value' => 'secret-123',
+                'domain' => '127.0.0.1',
+                'path' => '/',
+                'expires' => -1,
+                'httpOnly' => false,
+                'secure' => false,
+                'sameSite' => 'Lax',
+            ]],
+            'origins' => [[
+                'origin' => $this->getBaseUrl(),
+                'localStorage' => [[
+                    'name' => 'user',
+                    'value' => 'alice',
+                ]],
+            ]],
+        ]);
+
+        $this->context->setStorageState($storageState);
+
+        $this->goto('/index.html');
+
+        $cookieNames = array_column($this->context->cookies(), 'name');
+        self::assertContains('auth_token', $cookieNames);
+
+        self::assertSame('alice', $this->page->evaluate("() => localStorage.getItem('user')"));
+    }
+
+    public function testCanReloadASavedStorageState(): void
+    {
+        $this->goto('/index.html');
+        $this->page->evaluate("() => localStorage.setItem('session', 'saved-value')");
+        $this->context->addCookies([[
+            'name' => 'session_cookie',
+            'value' => 'cookie-value',
+            'domain' => '127.0.0.1',
+            'path' => '/',
+        ]]);
+
+        $file = sys_get_temp_dir().'/pw-php-storage-state-'.uniqid().'.json';
+
+        try {
+            $this->context->saveStorageState($file);
+
+            $fresh = $this->browser->newContext();
+
+            try {
+                $fresh->loadStorageState($file);
+
+                $page = $fresh->newPage();
+                $page->goto($this->getBaseUrl().'/index.html');
+
+                $cookieNames = array_column($fresh->cookies(), 'name');
+                self::assertContains('session_cookie', $cookieNames);
+
+                self::assertSame('saved-value', $page->evaluate("() => localStorage.getItem('session')"));
+            } finally {
+                $fresh->close();
+            }
+        } finally {
+            @unlink($file);
+        }
+    }
+}

--- a/tests/Unit/Browser/BrowserContextTest.php
+++ b/tests/Unit/Browser/BrowserContextTest.php
@@ -17,6 +17,7 @@ namespace Playwright\Tests\Unit\Browser;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Playwright\Browser\BrowserContext;
+use Playwright\Browser\StorageState;
 use Playwright\Configuration\PlaywrightConfig;
 use Playwright\Network\NetworkThrottling;
 use Playwright\Page\PageInterface;
@@ -309,6 +310,34 @@ final class BrowserContextTest extends TestCase
 
         $result = $this->context->storageState();
         $this->assertEquals([], $result);
+    }
+
+    public function testSetStorageState(): void
+    {
+        $state = StorageState::fromArray([
+            'cookies' => [[
+                'name' => 'session',
+                'value' => 'abc',
+                'domain' => 'example.com',
+                'path' => '/',
+                'expires' => -1,
+                'httpOnly' => false,
+                'secure' => false,
+                'sameSite' => 'Lax',
+            ]],
+            'origins' => [],
+        ]);
+
+        $this->mockTransport
+            ->expects($this->once())
+            ->method('send')
+            ->with([
+                'action' => 'context.setStorageState',
+                'contextId' => 'context_1',
+                'storageState' => $state->toArray(),
+            ]);
+
+        $this->context->setStorageState($state);
     }
 
     public function testSetGeolocation(): void


### PR DESCRIPTION
`BrowserContext::setStorageState()` (and `loadStorageState()`) had no effect: the PHP side sends `context.setStorageState`, but the Node server registry had no handler for it. 
 
The JSON-RPC transport swallowed the error silently, so the documented authentication flow failed without any message.

This adds the missing `ContextHandler` registry entry (the bundled Playwright 1.58 supports `context.setStorageState` natively), a functional round-trip test (save state, load it in a fresh context, verify cookies and localStorage), and a unit test for the payload.

Fixes #98
