### PR TITLE
Let operation timeouts extend the RPC deadline (fix #92)

### DIFF
--- a/src/Transport/JsonRpc/JsonRpcTransport.php
+++ b/src/Transport/JsonRpc/JsonRpcTransport.php
@@ -29,6 +29,12 @@ use Symfony\Component\Process\Process;
  */
 final class JsonRpcTransport implements TransportInterface
 {
+    /**
+     * Grace added to an operation's own timeout so the server-side error
+     * (with its call log) reaches the client instead of an RPC abort.
+     */
+    private const OPERATION_TIMEOUT_GRACE_MS = 5000;
+
     private ?Process $process = null;
     private ?JsonRpcClient $client = null;
     private bool $connected = false;
@@ -93,7 +99,8 @@ final class JsonRpcTransport implements TransportInterface
             $this->client = new ProcessJsonRpcClient(
                 process: $this->process,
                 processLauncher: $this->processLauncher,
-                logger: $this->logger
+                logger: $this->logger,
+                defaultTimeoutMs: null !== $timeout ? (float) $timeout * 1000 : 30000.0,
             );
 
             $this->client->setEventHandler(function (array $event): void {
@@ -168,6 +175,11 @@ final class JsonRpcTransport implements TransportInterface
                 $timeoutMs = (int) ($timeout * 1000);
             }
 
+            $operationTimeoutMs = $this->extractOperationTimeoutMs($message);
+            if (null !== $operationTimeoutMs) {
+                $timeoutMs = max($timeoutMs ?? 30000, $operationTimeoutMs + self::OPERATION_TIMEOUT_GRACE_MS);
+            }
+
             if (null === $this->client) {
                 throw new NetworkException('JSON-RPC client not available');
             }
@@ -185,6 +197,17 @@ final class JsonRpcTransport implements TransportInterface
             ]);
             throw $e;
         }
+    }
+
+    /**
+     * @param array<string, mixed> $message
+     */
+    private function extractOperationTimeoutMs(array $message): ?int
+    {
+        $options = $message['options'] ?? null;
+        $timeout = \is_array($options) && isset($options['timeout']) ? $options['timeout'] : ($message['timeout'] ?? null);
+
+        return is_numeric($timeout) && $timeout > 0 ? (int) $timeout : null;
     }
 
     /**

--- a/tests/Functional/Transport/RequestTimeoutTest.php
+++ b/tests/Functional/Transport/RequestTimeoutTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the community-maintained Playwright PHP project.
+ * It is not affiliated with or endorsed by Microsoft.
+ *
+ * (c) 2025-Present - Playwright PHP - https://github.com/playwright-php
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Playwright\Tests\Functional\Transport;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use Playwright\Configuration\PlaywrightConfig;
+use Playwright\Exception\TimeoutException;
+use Playwright\PlaywrightFactory;
+use Playwright\Tests\Functional\FunctionalTestCase;
+use Playwright\Transport\JsonRpc\JsonRpcTransport;
+use Symfony\Component\Process\ExecutableFinder;
+
+#[CoversClass(JsonRpcTransport::class)]
+final class RequestTimeoutTest extends FunctionalTestCase
+{
+    public function testAnOperationTimeoutIsNotCutByTheTransportDeadline(): void
+    {
+        $node = (new ExecutableFinder())->find('node');
+        if (null === $node) {
+            self::markTestSkipped('Node.js executable not found.');
+        }
+
+        $config = new PlaywrightConfig(nodePath: $node, timeoutMs: 5000);
+        $playwright = PlaywrightFactory::create($config);
+        $browser = $playwright->chromium()->launch();
+
+        try {
+            $context = $browser->newContext();
+            $page = $context->newPage();
+            $page->setContent('<html><body><p>empty</p></body></html>');
+
+            $start = microtime(true);
+
+            try {
+                $page->waitForSelector('#does-not-exist', ['timeout' => 9000]);
+                self::fail('Expected a TimeoutException');
+            } catch (TimeoutException $e) {
+                $elapsed = microtime(true) - $start;
+
+                // The wait must live for its full 9s and fail with the
+                // Playwright error, not be cut at 5s by the RPC deadline.
+                self::assertStringContainsString('Timeout 9000ms exceeded', $e->getMessage());
+                self::assertGreaterThan(8.0, $elapsed);
+            }
+        } finally {
+            $browser->close();
+        }
+    }
+}

--- a/tests/Unit/Transport/JsonRpc/JsonRpcTransportTest.php
+++ b/tests/Unit/Transport/JsonRpc/JsonRpcTransportTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Playwright\Exception\NetworkException;
 use Playwright\Tests\Mocks\TestLogger;
+use Playwright\Transport\JsonRpc\JsonRpcClient;
 use Playwright\Transport\JsonRpc\JsonRpcTransport;
 use Playwright\Transport\JsonRpc\ProcessLauncherInterface;
 use Symfony\Component\Process\InputStream;
@@ -219,5 +220,83 @@ final class JsonRpcTransportTest extends TestCase
         $transport->__destruct();
 
         $this->assertFalse($transport->isConnected());
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    private function createConnectedTransport(array $config): JsonRpcTransport
+    {
+        $mockProcess = $this->createMock(Process::class);
+        $mockProcess->method('isRunning')->willReturn(true);
+
+        $this->processLauncher->method('start')->willReturn($mockProcess);
+        $this->processLauncher->method('getInputStream')->willReturn($this->createMock(InputStream::class));
+
+        $transport = new JsonRpcTransport(
+            processLauncher: $this->processLauncher,
+            config: $config,
+            logger: $this->logger
+        );
+        $transport->connect();
+
+        return $transport;
+    }
+
+    private function injectClient(JsonRpcTransport $transport, JsonRpcClient $client): void
+    {
+        (new \ReflectionProperty($transport, 'client'))->setValue($transport, $client);
+    }
+
+    public function testSendPassesTheConfiguredTimeoutPerRequest(): void
+    {
+        $transport = $this->createConnectedTransport(['command' => ['node', 'server.js'], 'timeout' => 45]);
+
+        $client = $this->createMock(JsonRpcClient::class);
+        $client->expects($this->once())
+            ->method('sendRaw')
+            ->with($this->anything(), 45000.0)
+            ->willReturn([]);
+        $this->injectClient($transport, $client);
+
+        $transport->send(['action' => 'launch']);
+    }
+
+    public function testSendExtendsTheDeadlineForAnOperationTimeout(): void
+    {
+        $transport = $this->createConnectedTransport(['command' => ['node', 'server.js'], 'timeout' => 30]);
+
+        $client = $this->createMock(JsonRpcClient::class);
+        $client->expects($this->once())
+            ->method('sendRaw')
+            ->with($this->anything(), 40000.0)
+            ->willReturn([]);
+        $this->injectClient($transport, $client);
+
+        $transport->send([
+            'action' => 'page.waitForSelector',
+            'pageId' => 'page_1',
+            'selector' => '#x',
+            'options' => ['timeout' => 35000],
+        ]);
+    }
+
+    public function testSendKeepsTheConfiguredTimeoutWhenLarger(): void
+    {
+        $transport = $this->createConnectedTransport(['command' => ['node', 'server.js'], 'timeout' => 90]);
+
+        $client = $this->createMock(JsonRpcClient::class);
+        $client->expects($this->once())
+            ->method('sendRaw')
+            ->with($this->anything(), 90000.0)
+            ->willReturn([]);
+        $this->injectClient($transport, $client);
+
+        $transport->send([
+            'action' => 'page.waitForSelector',
+            'pageId' => 'page_1',
+            'selector' => '#x',
+            'options' => ['timeout' => 5000],
+        ]);
     }
 }


### PR DESCRIPTION
The per-request RPC deadline came only from `PlaywrightConfig::timeoutMs` (default 30s). 

Any operation whose own timeout exceeds it, like `waitForSelector(['timeout' => 60000])` or a slow browser launch, was killed by the transport layer with "JSON-RPC request timed out" instead of living until its own limit and reporting the real Playwright error.

The deadline is now `max(config timeout, operation timeout + 5s grace)` when the message carries an operation timeout (`options.timeout` or `timeout`). 

The grace window lets the server-side error, with its call log, reach the client instead of an RPC abort.

`ProcessJsonRpcClient`'s default timeout also aligns with the config instead of a hardcoded 30s, as suggested in the report.

Fixes #92
