### PR TITLE
Implement Tracing API & record expect assertions as trace groups

### DIFF
--- a/bin/lib/handlers.js
+++ b/bin/lib/handlers.js
@@ -49,6 +49,22 @@ class ContextHandler extends BaseHandler {
     return this.wrapResult(result);
   }
 
+  async handleTracing(command, method) {
+    const context = this.validateResource(this.contexts, command.contextId, 'Context')?.context;
+
+    const registry = CommandRegistry.create({
+      start: () => context.tracing.start(command.options || {}),
+      startChunk: () => context.tracing.startChunk(command.options || {}),
+      stop: () => context.tracing.stop(command.options || {}),
+      stopChunk: () => context.tracing.stopChunk(command.options || {}),
+      group: () => context.tracing.group(command.name, command.location ? { location: { file: command.location } } : undefined),
+      groupEnd: () => context.tracing.groupEnd()
+    });
+
+    const result = await ErrorHandler.safeExecute(() => this.executeWithRegistry(registry, method), { method, contextId: command.contextId });
+    return this.wrapResult(result);
+  }
+
   async handleClock(command, method) {
     const context = this.validateResource(this.contexts, command.contextId, 'Context')?.context;
 

--- a/bin/lib/handlers.js
+++ b/bin/lib/handlers.js
@@ -15,8 +15,8 @@ class ContextHandler extends BaseHandler {
       clearCookies: () => context.clearCookies(command.options || {}),
       grantPermissions: () => context.grantPermissions(command.permissions, command.origin ? { origin: command.origin } : undefined),
       clearPermissions: () => context.clearPermissions(),
-      startTracing: () => context.tracing.start(command.options || {}),
-      stopTracing: () => context.tracing.stop({ path: command.path }),
+      startTracing: async () => { await context.tracing.start(command.options || {}); context.__phpTracingActive = true; },
+      stopTracing: async () => { context.__phpTracingActive = false; await context.tracing.stop({ path: command.path }); },
       waitForEvent: async () => {
         // Special-case 'page' event to return a serializable payload
         if (command.event === 'page') {
@@ -53,12 +53,16 @@ class ContextHandler extends BaseHandler {
     const context = this.validateResource(this.contexts, command.contextId, 'Context')?.context;
 
     const registry = CommandRegistry.create({
-      start: () => context.tracing.start(command.options || {}),
+      start: async () => { await context.tracing.start(command.options || {}); context.__phpTracingActive = true; },
       startChunk: () => context.tracing.startChunk(command.options || {}),
-      stop: () => context.tracing.stop(command.options || {}),
+      stop: async () => { context.__phpTracingActive = false; await context.tracing.stop(command.options || {}); },
       stopChunk: () => context.tracing.stopChunk(command.options || {}),
-      group: () => context.tracing.group(command.name, command.location ? { location: { file: command.location } } : undefined),
-      groupEnd: () => context.tracing.groupEnd()
+      // Groups are silently skipped when tracing is off so callers (e.g. expect
+      // assertions) can emit them unconditionally
+      group: () => context.__phpTracingActive
+        ? context.tracing.group(command.name, command.location ? { location: { file: command.location } } : undefined)
+        : { skipped: true },
+      groupEnd: () => context.__phpTracingActive ? context.tracing.groupEnd() : { skipped: true }
     });
 
     const result = await ErrorHandler.safeExecute(() => this.executeWithRegistry(registry, method), { method, contextId: command.contextId });

--- a/bin/playwright-server.js
+++ b/bin/playwright-server.js
@@ -74,7 +74,14 @@ class PlaywrightServer extends BaseHandler {
       frame: () => this.frameHandler.handle(command, actionMethod),
       browserServer: () => this.handleBrowserServer(command, actionMethod),
       selectors: () => this.selectorsHandler.handle(command, actionMethod),
-      clock: () => this.contextHandler.handleClock(command, actionMethod)
+      clock: () => this.contextHandler.handleClock(command, actionMethod),
+      // Tracing actions are flat names (no dot), sent by the PHP Tracing class
+      tracingStart: () => this.contextHandler.handleTracing(command, 'start'),
+      tracingStartChunk: () => this.contextHandler.handleTracing(command, 'startChunk'),
+      tracingStop: () => this.contextHandler.handleTracing(command, 'stop'),
+      tracingStopChunk: () => this.contextHandler.handleTracing(command, 'stopChunk'),
+      tracingGroup: () => this.contextHandler.handleTracing(command, 'group'),
+      tracingGroupEnd: () => this.contextHandler.handleTracing(command, 'groupEnd')
     });
 
     if (handlerRegistry.has(actionPrefix)) {

--- a/docs/guide/testing-with-phpunit.md
+++ b/docs/guide/testing-with-phpunit.md
@@ -100,3 +100,7 @@ When a test fails, the library automatically provides tools to help you debug:
 `PW_TRACE` is the single switch for tracing. It is also read by `PlaywrightConfigBuilder::fromEnv()`: every browser
 context created from that configuration records a trace, saved to `PW_TRACE_DIR` (default: `traces/` in the working
 directory) when the context closes.
+
+When tracing is active, every `$this->expect(...)` assertion appears in the trace as a named group, such as
+`expect(#submit).toBeVisible`, with the polled calls nested inside it. Outside the trait, pass the tracing handle
+explicitly: `expect($locator, $context->tracing())`.

--- a/src/Browser/BrowserContext.php
+++ b/src/Browser/BrowserContext.php
@@ -27,6 +27,8 @@ use Playwright\Network\NetworkThrottling;
 use Playwright\Network\Route;
 use Playwright\Page\Page;
 use Playwright\Page\PageInterface;
+use Playwright\Tracing\Tracing;
+use Playwright\Tracing\TracingInterface;
 use Playwright\Transport\TransportInterface;
 
 final class BrowserContext implements BrowserContextInterface, EventDispatcherInterface
@@ -55,6 +57,8 @@ final class BrowserContext implements BrowserContextInterface, EventDispatcherIn
 
     private bool $autoTracing = false;
 
+    private ?TracingInterface $tracing = null;
+
     public function __construct(
         private readonly TransportInterface $transport,
         private readonly string $contextId,
@@ -82,6 +86,11 @@ final class BrowserContext implements BrowserContextInterface, EventDispatcherIn
     public function clock(): ClockInterface
     {
         return $this->clock;
+    }
+
+    public function tracing(): TracingInterface
+    {
+        return $this->tracing ??= new Tracing($this->transport, $this->contextId);
     }
 
     /**

--- a/src/Browser/BrowserContextInterface.php
+++ b/src/Browser/BrowserContextInterface.php
@@ -18,6 +18,7 @@ use Playwright\API\APIRequestContextInterface;
 use Playwright\Clock\ClockInterface;
 use Playwright\Network\NetworkThrottling;
 use Playwright\Page\PageInterface;
+use Playwright\Tracing\TracingInterface;
 
 /**
  * @method ClockInterface clock()                                                                   The context's clock, to fake and advance time
@@ -105,6 +106,11 @@ interface BrowserContextInterface
     public function unroute(string $url, ?callable $handler = null): void;
 
     public function getEnv(string $name): ?string;
+
+    /**
+     * Tracing helper associated with this context.
+     */
+    public function tracing(): TracingInterface;
 
     /**
      * @param array<string, mixed> $options

--- a/src/Testing/Expect.php
+++ b/src/Testing/Expect.php
@@ -17,6 +17,7 @@ namespace Playwright\Testing;
 use Playwright\Assertions\Failure\AssertionException;
 use Playwright\Locator\LocatorInterface;
 use Playwright\Page\PageInterface;
+use Playwright\Tracing\TracingInterface;
 
 final class Expect implements ExpectInterface
 {
@@ -28,6 +29,7 @@ final class Expect implements ExpectInterface
 
     public function __construct(
         private readonly LocatorInterface|PageInterface $subject,
+        private readonly ?TracingInterface $tracing = null,
     ) {
     }
 
@@ -371,6 +373,38 @@ final class Expect implements ExpectInterface
      * Core retry assertion mechanism with configurable timeout and polling.
      */
     private function retryAssertion(callable $condition, bool $expectedResult, string $message, ?callable $failureMessageProvider = null): void
+    {
+        if (null === $this->tracing) {
+            $this->runAssertion($condition, $expectedResult, $message, $failureMessageProvider);
+
+            return;
+        }
+
+        $this->tracing->group($this->traceGroupName());
+
+        try {
+            $this->runAssertion($condition, $expectedResult, $message, $failureMessageProvider);
+        } finally {
+            $this->tracing->groupEnd();
+        }
+    }
+
+    private function traceGroupName(): string
+    {
+        $matcher = 'assertion';
+        foreach (\debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS, 4) as $frame) {
+            if (self::class === ($frame['class'] ?? null) && \str_starts_with($frame['function'], 'to')) {
+                $matcher = $frame['function'];
+                break;
+            }
+        }
+
+        $subject = $this->subject instanceof LocatorInterface ? $this->subject->getSelector() : 'page';
+
+        return \sprintf('expect(%s).%s%s', $subject, $this->negated ? 'not.' : '', $matcher);
+    }
+
+    private function runAssertion(callable $condition, bool $expectedResult, string $message, ?callable $failureMessageProvider = null): void
     {
         $startTime = \microtime(true);
         $endTime = $startTime + ($this->timeoutMs / 1000);

--- a/src/Testing/PlaywrightTestCaseTrait.php
+++ b/src/Testing/PlaywrightTestCaseTrait.php
@@ -125,7 +125,7 @@ trait PlaywrightTestCaseTrait
 
     protected function expect(LocatorInterface|PageInterface $subject): ExpectInterface
     {
-        return new ExpectDecorator(new Expect($subject), $this);
+        return new ExpectDecorator(new Expect($subject, $this->context->tracing()), $this);
     }
 
     private function resolveLogger(LoggerInterface $logger): LoggerInterface

--- a/src/Testing/functions.php
+++ b/src/Testing/functions.php
@@ -16,8 +16,9 @@ namespace Playwright\Testing;
 
 use Playwright\Locator\LocatorInterface;
 use Playwright\Page\PageInterface;
+use Playwright\Tracing\TracingInterface;
 
-function expect(LocatorInterface|PageInterface $subject): ExpectInterface
+function expect(LocatorInterface|PageInterface $subject, ?TracingInterface $tracing = null): ExpectInterface
 {
-    return new Expect($subject);
+    return new Expect($subject, $tracing);
 }

--- a/src/Tracing/Tracing.php
+++ b/src/Tracing/Tracing.php
@@ -68,22 +68,20 @@ final class Tracing implements TracingInterface
         ]);
     }
 
-    /**
-     * @deprecated Use test.step() instead
-     */
-    public function group(string $name, string $location): void
+    public function group(string $name, ?string $location = null): void
     {
-        $this->transport->send([
+        $payload = [
             'action' => 'tracingGroup',
             'contextId' => $this->contextId,
             'name' => $name,
-            'location' => $location,
-        ]);
+        ];
+        if (null !== $location) {
+            $payload['location'] = $location;
+        }
+
+        $this->transport->send($payload);
     }
 
-    /**
-     * @deprecated Use test.step() instead
-     */
     public function groupEnd(): void
     {
         $this->transport->send([

--- a/src/Tracing/TracingInterface.php
+++ b/src/Tracing/TracingInterface.php
@@ -49,13 +49,7 @@ interface TracingInterface
      */
     public function stopChunk(array|StopChunkOptions $options = []): void;
 
-    /**
-     * @deprecated Use test.step() instead
-     */
-    public function group(string $name, string $location): void;
+    public function group(string $name, ?string $location = null): void;
 
-    /**
-     * @deprecated Use test.step() instead
-     */
     public function groupEnd(): void;
 }

--- a/tests/Functional/Tracing/ExpectTraceGroupsTest.php
+++ b/tests/Functional/Tracing/ExpectTraceGroupsTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the community-maintained Playwright PHP project.
+ * It is not affiliated with or endorsed by Microsoft.
+ *
+ * (c) 2025-Present - Playwright PHP - https://github.com/playwright-php
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Playwright\Tests\Functional\Tracing;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use Playwright\Testing\Expect;
+use Playwright\Tests\Functional\FunctionalTestCase;
+use Playwright\Tracing\Tracing;
+
+#[CoversClass(Expect::class)]
+#[CoversClass(Tracing::class)]
+final class ExpectTraceGroupsTest extends FunctionalTestCase
+{
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDir = sys_get_temp_dir().'/playwright-expect-groups-'.uniqid();
+        mkdir($this->tempDir, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->tempDir.'/*') ?: [] as $file) {
+            @unlink($file);
+        }
+        if (is_dir($this->tempDir)) {
+            @rmdir($this->tempDir);
+        }
+        parent::tearDown();
+    }
+
+    public function testExpectAssertionsAppearAsGroupsInTheTrace(): void
+    {
+        $tracePath = $this->tempDir.'/trace.zip';
+
+        $this->goto('/index.html');
+
+        $this->context->tracing()->start(['snapshots' => true]);
+
+        $this->expect($this->page->locator('#heading'))->toBeVisible();
+        $this->expect($this->page)->toHaveTitle('Index - Playwright PHP Tests');
+
+        $this->context->tracing()->stop(['path' => $tracePath]);
+
+        $events = $this->readTraceEvents($tracePath);
+        self::assertStringContainsString('"method":"tracingGroup"', $events);
+        self::assertStringContainsString('expect(#heading).toBeVisible', $events);
+        self::assertStringContainsString('expect(page).toHaveTitle', $events);
+    }
+
+    public function testExpectStillWorksWhenTracingIsNotActive(): void
+    {
+        $this->goto('/index.html');
+
+        $this->expect($this->page->locator('#heading'))->toBeVisible();
+
+        self::assertTrue(true);
+    }
+
+    private function readTraceEvents(string $zipPath): string
+    {
+        $zip = new \ZipArchive();
+        self::assertTrue($zip->open($zipPath));
+
+        $events = '';
+        for ($i = 0; $i < $zip->numFiles; ++$i) {
+            $name = (string) $zip->getNameIndex($i);
+            if (str_ends_with($name, '.trace')) {
+                $events .= (string) $zip->getFromIndex($i);
+            }
+        }
+        $zip->close();
+
+        self::assertNotSame('', $events, 'No .trace events file found in the archive');
+
+        return $events;
+    }
+}

--- a/tests/Functional/Tracing/TracingApiTest.php
+++ b/tests/Functional/Tracing/TracingApiTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the community-maintained Playwright PHP project.
+ * It is not affiliated with or endorsed by Microsoft.
+ *
+ * (c) 2025-Present - Playwright PHP - https://github.com/playwright-php
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Playwright\Tests\Functional\Tracing;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use Playwright\Browser\BrowserContext;
+use Playwright\Tests\Functional\FunctionalTestCase;
+use Playwright\Tracing\Tracing;
+
+#[CoversClass(Tracing::class)]
+#[CoversClass(BrowserContext::class)]
+final class TracingApiTest extends FunctionalTestCase
+{
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDir = sys_get_temp_dir().'/playwright-tracing-api-'.uniqid();
+        mkdir($this->tempDir, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->tempDir.'/*') ?: [] as $file) {
+            @unlink($file);
+        }
+        if (is_dir($this->tempDir)) {
+            @rmdir($this->tempDir);
+        }
+        parent::tearDown();
+    }
+
+    public function testTracingStartAndStopProduceATraceArchive(): void
+    {
+        $tracePath = $this->tempDir.'/trace.zip';
+
+        $this->goto('/index.html');
+
+        $tracing = $this->context->tracing();
+        $tracing->start(['screenshots' => false, 'snapshots' => true]);
+
+        $this->page->locator('#heading')->textContent();
+
+        $tracing->stop(['path' => $tracePath]);
+
+        self::assertFileExists($tracePath);
+        self::assertGreaterThan(0, (int) filesize($tracePath));
+        self::assertStringContainsString('textContent', $this->readTraceEvents($tracePath));
+    }
+
+    public function testGroupsAppearInTheTrace(): void
+    {
+        $tracePath = $this->tempDir.'/trace-group.zip';
+
+        $this->goto('/index.html');
+
+        $tracing = $this->context->tracing();
+        $tracing->start(['snapshots' => true]);
+
+        $tracing->group('my custom step');
+        $this->page->locator('#heading')->isVisible();
+        $tracing->groupEnd();
+
+        $tracing->stop(['path' => $tracePath]);
+
+        $events = $this->readTraceEvents($tracePath);
+        self::assertStringContainsString('"method":"tracingGroup"', $events);
+        self::assertStringContainsString('my custom step', $events);
+    }
+
+    public function testChunksProduceSeparateArchives(): void
+    {
+        $chunkPath = $this->tempDir.'/chunk.zip';
+
+        $this->goto('/index.html');
+
+        $tracing = $this->context->tracing();
+        $tracing->start(['snapshots' => true]);
+
+        $tracing->startChunk(['title' => 'chunk one']);
+        $this->page->locator('#heading')->textContent();
+        $tracing->stopChunk(['path' => $chunkPath]);
+
+        $tracing->stop();
+
+        self::assertFileExists($chunkPath);
+        self::assertGreaterThan(0, (int) filesize($chunkPath));
+    }
+
+    private function readTraceEvents(string $zipPath): string
+    {
+        $zip = new \ZipArchive();
+        self::assertTrue($zip->open($zipPath));
+
+        $events = '';
+        for ($i = 0; $i < $zip->numFiles; ++$i) {
+            $name = (string) $zip->getNameIndex($i);
+            if (str_ends_with($name, '.trace')) {
+                $events .= (string) $zip->getFromIndex($i);
+            }
+        }
+        $zip->close();
+
+        self::assertNotSame('', $events, 'No .trace events file found in the archive');
+
+        return $events;
+    }
+}

--- a/tests/Unit/Browser/BrowserContextTest.php
+++ b/tests/Unit/Browser/BrowserContextTest.php
@@ -21,6 +21,7 @@ use Playwright\Browser\StorageState;
 use Playwright\Configuration\PlaywrightConfig;
 use Playwright\Network\NetworkThrottling;
 use Playwright\Page\PageInterface;
+use Playwright\Tracing\TracingInterface;
 use Playwright\Transport\TransportInterface;
 
 #[CoversClass(BrowserContext::class)]
@@ -402,6 +403,14 @@ final class BrowserContextTest extends TestCase
             ]);
 
         $this->context->unroute('**/*.api');
+    }
+
+    public function testTracingReturnsTheSameInstance(): void
+    {
+        $tracing = $this->context->tracing();
+
+        $this->assertInstanceOf(TracingInterface::class, $tracing);
+        $this->assertSame($tracing, $this->context->tracing());
     }
 
     public function testGetEnv(): void

--- a/tests/Unit/Testing/ExpectFactoryTest.php
+++ b/tests/Unit/Testing/ExpectFactoryTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the community-maintained Playwright PHP project.
+ * It is not affiliated with or endorsed by Microsoft.
+ *
+ * (c) 2025-Present - Playwright PHP - https://github.com/playwright-php
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Playwright\Tests\Unit\Testing;
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\TestCase;
+use Playwright\Browser\BrowserContextInterface;
+use Playwright\Locator\LocatorInterface;
+use Playwright\Testing\ExpectInterface;
+use Playwright\Testing\PlaywrightTestCaseTrait;
+use Playwright\Tracing\TracingInterface;
+
+use function Playwright\Testing\expect;
+
+#[CoversTrait(PlaywrightTestCaseTrait::class)]
+#[CoversFunction('Playwright\Testing\expect')]
+final class ExpectFactoryTest extends TestCase
+{
+    private function createVisibleLocator(): LocatorInterface
+    {
+        $locator = $this->createMock(LocatorInterface::class);
+        $locator->method('isVisible')->willReturn(true);
+        $locator->method('getSelector')->willReturn('#x');
+
+        return $locator;
+    }
+
+    public function testTheTraitInjectsTheContextTracing(): void
+    {
+        $tracing = $this->createMock(TracingInterface::class);
+        $tracing->expects($this->once())->method('group');
+        $tracing->expects($this->once())->method('groupEnd');
+
+        $context = $this->createMock(BrowserContextInterface::class);
+        $context->method('tracing')->willReturn($tracing);
+
+        $harness = new class('harness') extends TestCase {
+            use PlaywrightTestCaseTrait;
+
+            public function callExpect(BrowserContextInterface $context, LocatorInterface $subject): ExpectInterface
+            {
+                $this->context = $context;
+
+                return $this->expect($subject);
+            }
+        };
+
+        $harness->callExpect($context, $this->createVisibleLocator())->toBeVisible();
+    }
+
+    public function testTheExpectFunctionAcceptsATracingHandle(): void
+    {
+        $tracing = $this->createMock(TracingInterface::class);
+        $tracing->expects($this->once())->method('group')->with('expect(#x).toBeVisible');
+        $tracing->expects($this->once())->method('groupEnd');
+
+        expect($this->createVisibleLocator(), $tracing)->toBeVisible();
+    }
+
+    public function testTheExpectFunctionWorksWithoutTracing(): void
+    {
+        expect($this->createVisibleLocator())->toBeVisible();
+
+        self::assertTrue(true);
+    }
+}

--- a/tests/Unit/Testing/ExpectTraceGroupTest.php
+++ b/tests/Unit/Testing/ExpectTraceGroupTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the community-maintained Playwright PHP project.
+ * It is not affiliated with or endorsed by Microsoft.
+ *
+ * (c) 2025-Present - Playwright PHP - https://github.com/playwright-php
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Playwright\Tests\Unit\Testing;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Playwright\Assertions\Failure\AssertionException;
+use Playwright\Locator\LocatorInterface;
+use Playwright\Testing\Expect;
+use Playwright\Tracing\TracingInterface;
+
+#[CoversClass(Expect::class)]
+final class ExpectTraceGroupTest extends TestCase
+{
+    private function createVisibleLocator(): LocatorInterface
+    {
+        $locator = $this->createMock(LocatorInterface::class);
+        $locator->method('isVisible')->willReturn(true);
+        $locator->method('getSelector')->willReturn('#heading');
+
+        return $locator;
+    }
+
+    public function testAssertionIsWrappedInATracingGroup(): void
+    {
+        $tracing = $this->createMock(TracingInterface::class);
+        $tracing->expects($this->once())
+            ->method('group')
+            ->with('expect(#heading).toBeVisible');
+        $tracing->expects($this->once())
+            ->method('groupEnd');
+
+        (new Expect($this->createVisibleLocator(), $tracing))->toBeVisible();
+    }
+
+    public function testNegatedAssertionGroupNameContainsNot(): void
+    {
+        $tracing = $this->createMock(TracingInterface::class);
+        $tracing->expects($this->once())
+            ->method('group')
+            ->with('expect(#heading).not.toBeHidden');
+        $tracing->expects($this->once())
+            ->method('groupEnd');
+
+        $locator = $this->createMock(LocatorInterface::class);
+        $locator->method('isVisible')->willReturn(true);
+        $locator->method('getSelector')->willReturn('#heading');
+
+        (new Expect($locator, $tracing))->not()->toBeHidden();
+    }
+
+    public function testGroupIsClosedWhenTheAssertionFails(): void
+    {
+        $tracing = $this->createMock(TracingInterface::class);
+        $tracing->expects($this->once())->method('group');
+        $tracing->expects($this->once())->method('groupEnd');
+
+        $locator = $this->createMock(LocatorInterface::class);
+        $locator->method('isVisible')->willReturn(false);
+        $locator->method('getSelector')->willReturn('#heading');
+
+        $expect = new Expect($locator, $tracing);
+        $expect->withTimeout(50)->withPollInterval(10);
+
+        try {
+            $expect->toBeVisible();
+            self::fail('Expected an AssertionException');
+        } catch (AssertionException) {
+        }
+    }
+
+    public function testNoTracingMeansNoGroups(): void
+    {
+        (new Expect($this->createVisibleLocator()))->toBeVisible();
+
+        self::assertTrue(true);
+    }
+}

--- a/tests/Unit/Tracing/TracingTest.php
+++ b/tests/Unit/Tracing/TracingTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the community-maintained Playwright PHP project.
+ * It is not affiliated with or endorsed by Microsoft.
+ *
+ * (c) 2025-Present - Playwright PHP - https://github.com/playwright-php
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Playwright\Tests\Unit\Tracing;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Playwright\Tracing\Tracing;
+use Playwright\Transport\TransportInterface;
+
+#[CoversClass(Tracing::class)]
+final class TracingTest extends TestCase
+{
+    private TransportInterface $transport;
+    private Tracing $tracing;
+
+    protected function setUp(): void
+    {
+        $this->transport = $this->createMock(TransportInterface::class);
+        $this->tracing = new Tracing($this->transport, 'context_1');
+    }
+
+    public function testStartSendsOptions(): void
+    {
+        $this->transport->expects($this->once())
+            ->method('send')
+            ->with([
+                'action' => 'tracingStart',
+                'contextId' => 'context_1',
+                'options' => ['screenshots' => true, 'snapshots' => true],
+            ])
+            ->willReturn([]);
+
+        $this->tracing->start(['screenshots' => true, 'snapshots' => true]);
+    }
+
+    public function testStopSendsPath(): void
+    {
+        $this->transport->expects($this->once())
+            ->method('send')
+            ->with([
+                'action' => 'tracingStop',
+                'contextId' => 'context_1',
+                'options' => ['path' => '/tmp/trace.zip'],
+            ])
+            ->willReturn([]);
+
+        $this->tracing->stop(['path' => '/tmp/trace.zip']);
+    }
+
+    public function testGroupSendsNameWithoutLocation(): void
+    {
+        $this->transport->expects($this->once())
+            ->method('send')
+            ->with([
+                'action' => 'tracingGroup',
+                'contextId' => 'context_1',
+                'name' => 'my step',
+            ])
+            ->willReturn([]);
+
+        $this->tracing->group('my step');
+    }
+
+    public function testGroupSendsLocationWhenProvided(): void
+    {
+        $this->transport->expects($this->once())
+            ->method('send')
+            ->with([
+                'action' => 'tracingGroup',
+                'contextId' => 'context_1',
+                'name' => 'my step',
+                'location' => 'tests/MyTest.php',
+            ])
+            ->willReturn([]);
+
+        $this->tracing->group('my step', 'tests/MyTest.php');
+    }
+
+    public function testGroupEndSendsAction(): void
+    {
+        $this->transport->expects($this->once())
+            ->method('send')
+            ->with([
+                'action' => 'tracingGroupEnd',
+                'contextId' => 'context_1',
+            ])
+            ->willReturn([]);
+
+        $this->tracing->groupEnd();
+    }
+}


### PR DESCRIPTION
Traces produced by `playwright-php` contained raw API calls but nothing that identified higher-level intent, and the shipped tracing API could not help because it was non-functional.

## Implement the tracing API server-side. 

The public `Playwright\Tracing\Tracing` class (`start()`, `stop()`, `startChunk()`, `stopChunk()`, `group()`, `groupEnd()`) sent actions that the Node server never handled, and the class was never instantiated. 

The six server-side actions now exist, the instance is exposed through `BrowserContextInterface::tracing()`, and `group()`'s location parameter is optional. Functional tests assert against real trace archives: `start()`/`stop()` produce a readable trace, groups appear as `tracingGroup` entries, and chunks produce separate archives.

## Record `expect()` assertions as trace groups. 

The `expect.toBeVisible(...)` entries visible in `@playwright/test` traces come from the test runner, not the library; PHP's `expect()` polls raw API calls, so traces only showed repeated `isVisible` calls. Assertions are now wrapped in named groups (`expect(#heading).toBeVisible`, `expect(page).toHaveTitle`, including `not.` variants) with the polled calls nested inside. 

The PHPUnit trait injects the context tracing automatically; outside the trait, `expect($locator, $context->tracing())` opts in. 

Groups are skipped server-side when tracing is not active, so assertions are unaffected outside tracing sessions.

Fixes #91
