### PR TITLE
Add issue templates and contact links

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug_report.md
+++ b/.github/ISSUE_TEMPLATE/1-bug_report.md
@@ -1,0 +1,44 @@
+---
+name: 'Bug Report'
+about: Report a bug in existing features
+title: ''
+labels: ['bug']
+assignees: ''
+---
+
+<!-- ======================== Guidelines ============================
+
+Thank you for taking the time to report a bug!
+
+- Fill in the environment: `composer show playwright-php/playwright`,
+  `php -v`, `node -v`;
+- Provide a minimal, self-contained code sample that reproduces the
+  problem;
+- Describe what you expected, then what actually happened;
+- If an exception is thrown, include the exact message and the full
+  stack trace.
+
+Playwright PHP is community-driven: kindness, respect and patience are more than welcome.
+
+============================= Guidelines ======================== -->
+
+### Environment
+
+- playwright-php/playwright:
+- PHP:
+- Node.js:
+- Browser: chromium / firefox / webkit
+
+### How to reproduce
+
+```php
+// A minimal, self-contained code sample
+```
+
+### Expected behavior
+
+
+### Actual behavior
+
+<!-- If an exception is thrown, include the exact message and the full stack trace. -->
+

--- a/.github/ISSUE_TEMPLATE/2-feature_request.md
+++ b/.github/ISSUE_TEMPLATE/2-feature_request.md
@@ -1,0 +1,34 @@
+---
+name: 'Feature Request'
+about: Suggest ideas for new features or enhancements
+title: ''
+labels: ['RFC']
+assignees: ''
+---
+
+<!-- ======================== Guidelines ============================
+
+Thank you for suggesting an improvement!
+
+Describe your idea
+- Explain the problem you are trying to solve, before the solution;
+- Show the API you have in mind as a code sample;
+- Mention how Playwright solves this in other languages, if it does.
+
+Keep in mind
+- The PHP API mirrors upstream Playwright where it makes sense;
+- Features are only added when the underlying Playwright API supports them.
+
+============================= Guidelines ======================== -->
+
+### Problem
+
+
+### Proposed API
+
+```php
+// How you would like to use it
+```
+
+### Alternatives considered
+

--- a/.github/ISSUE_TEMPLATE/3-documentation.md
+++ b/.github/ISSUE_TEMPLATE/3-documentation.md
@@ -1,0 +1,26 @@
+---
+name: 'Documentation'
+about: Report gaps, errors or unclear parts in the documentation
+title: ''
+labels: ['documentation']
+assignees: ''
+---
+
+<!-- ======================== Guidelines ============================
+
+Thank you for helping us improve the documentation!
+
+- Link the page or section concerned (repository docs or playwright-php.dev);
+- Quote the passage that is wrong, outdated or unclear;
+- If you can, suggest the wording or example you expected to find.
+
+============================= Guidelines ======================== -->
+
+### Page or section
+
+
+### What is wrong or missing
+
+
+### Suggested improvement
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+blank_issues_enabled: false
+contact_links:
+    - name: Playwright PHP website
+      url: https://playwright-php.dev
+      about: Guides, examples, recipes and the full API reference
+    - name: Questions and help
+      url: https://github.com/playwright-php/playwright/discussions
+      about: Ask questions and discuss usage in GitHub Discussions
+


### PR DESCRIPTION
Three issue forms (bug report with environment details, feature request labeled RFC, documentation) and a config that points questions to the website and GitHub Discussions. Blank issues are disabled.