### PR TITLE
Transport request bodies as base64 postDataBuffer

### DIFF
--- a/bin/playwright-server.js
+++ b/bin/playwright-server.js
@@ -172,7 +172,13 @@ class PlaywrightServer extends BaseHandler {
   extractRequestData(req) {
     let postData = null;
     try { postData = req.postData(); } catch {}
-    return { url: req.url(), method: req.method(), headers: req.headers(), postData: postData ?? null, resourceType: req.resourceType ? req.resourceType() : 'document' };
+    // postData() is lossy for non-UTF8 bodies; ship the raw bytes as base64
+    let postDataBuffer = null;
+    try {
+      const buffer = req.postDataBuffer ? req.postDataBuffer() : null;
+      if (buffer) postDataBuffer = buffer.toString('base64');
+    } catch {}
+    return { url: req.url(), method: req.method(), headers: req.headers(), postData: postData ?? null, postDataBuffer, resourceType: req.resourceType ? req.resourceType() : 'document' };
   }
 
   serializeResponse(response) {

--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -201,8 +201,14 @@ final class Request implements RequestInterface
     public function postDataBuffer(): ?string
     {
         $buffer = $this->data['postDataBuffer'] ?? null;
+        if (!is_string($buffer)) {
+            return null;
+        }
 
-        return is_string($buffer) ? $buffer : null;
+        // The transport carries the raw bytes as base64
+        $decoded = base64_decode($buffer, true);
+
+        return false === $decoded ? null : $decoded;
     }
 
     /**

--- a/tests/Functional/Network/RequestBodyTest.php
+++ b/tests/Functional/Network/RequestBodyTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the community-maintained Playwright PHP project.
+ * It is not affiliated with or endorsed by Microsoft.
+ *
+ * (c) 2025-Present - Playwright PHP - https://github.com/playwright-php
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Playwright\Tests\Functional\Network;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use Playwright\Network\Request;
+use Playwright\Tests\Functional\FunctionalTestCase;
+
+#[CoversClass(Request::class)]
+final class RequestBodyTest extends FunctionalTestCase
+{
+    public function testPostDataBufferCarriesBinaryBodies(): void
+    {
+        $this->goto('/index.html');
+
+        $binary = "\xff\xfe\x00\x41\x80";
+        $captured = null;
+
+        $this->page->route('**/upload', function ($route) use (&$captured) {
+            $captured = $route->request()->postDataBuffer();
+            $route->fulfill(['status' => 204, 'body' => '']);
+        });
+
+        $this->page->evaluate("async () => {
+            const binary = new Uint8Array([0xff, 0xfe, 0x00, 0x41, 0x80]);
+            await fetch('/upload', { method: 'POST', body: binary });
+        }");
+
+        self::assertSame($binary, $captured);
+    }
+
+    public function testPostDataBufferMatchesTextBodies(): void
+    {
+        $this->goto('/index.html');
+
+        $captured = null;
+
+        $this->page->route('**/upload', function ($route) use (&$captured) {
+            $captured = $route->request()->postDataBuffer();
+            $route->fulfill(['status' => 204, 'body' => '']);
+        });
+
+        $this->page->evaluate("async () => {
+            await fetch('/upload', { method: 'POST', body: 'plain text body' });
+        }");
+
+        self::assertSame('plain text body', $captured);
+    }
+}

--- a/tests/Unit/Network/RequestTest.php
+++ b/tests/Unit/Network/RequestTest.php
@@ -199,12 +199,19 @@ final class RequestTest extends TestCase
         $this->assertFalse($request->isNavigationRequest());
     }
 
-    public function testPostDataBuffer(): void
+    public function testPostDataBufferDecodesTheBase64Transport(): void
     {
-        $request = $this->createRequest(['postDataBuffer' => 'binary-data']);
-        $this->assertSame('binary-data', $request->postDataBuffer());
+        $binary = "\xff\xfe\x00\x41\x80";
+        $request = $this->createRequest(['postDataBuffer' => base64_encode($binary)]);
+        $this->assertSame($binary, $request->postDataBuffer());
 
         $request = $this->createRequest();
+        $this->assertNull($request->postDataBuffer());
+    }
+
+    public function testPostDataBufferReturnsNullOnInvalidBase64(): void
+    {
+        $request = $this->createRequest(['postDataBuffer' => 'not base64!']);
         $this->assertNull($request->postDataBuffer());
     }
 


### PR DESCRIPTION
`extractRequestData` never shipped `postDataBuffer`, so `RequestInterface::postDataBuffer()` always returned null. Worse, `postData()` corrupts non-UTF8 bytes on their way through the JSON transport, so intercepted binary POST bodies (file uploads, some multipart payloads) arrive mangled with no way to recover them.

The server now sends the raw body base64-encoded in a `postDataBuffer` field and `Request::postDataBuffer()` decodes it. Functional tests intercept a binary and a text POST and assert byte-for-byte equality.


