### PR TITLE
Add the missing v1.2.0 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@
   `Page::pause()`, `Response::headerValue()`. They will move to real interface
   declarations in the next major.
 
+## [1.2.0] - 2026-02-25
+
+### Added
+- `PLAYWRIGHT_BROWSERS_PATH` is read by `PlaywrightConfigBuilder::fromEnv()` and
+  forwarded to the Node.js server, so a shared browser installation can be
+  reused instead of a per-project one (#71)
+
+### Fixed
+- `Page::waitForLoadState()` no longer fails with `Unknown action`: the action
+  was never registered in the Node bridge (#65)
+- Cookie expiry accepts an integer or a float timestamp (#67)
+
 ## [1.1.0] - 2025-12-23
 
 ### Added


### PR DESCRIPTION
`v1.2.0` was tagged on 2026-02-25 without a CHANGELOG entry, so the file went straight from `[Unreleased]` to `1.1.0`. 

Reconstructed from the `v1.1.0..v1.2.0` range.