### PR TITLE
Send `isNavigationRequest` in the route request payload

### DIFF
--- a/bin/playwright-server.js
+++ b/bin/playwright-server.js
@@ -185,7 +185,7 @@ class PlaywrightServer extends BaseHandler {
       const buffer = req.postDataBuffer ? req.postDataBuffer() : null;
       if (buffer) postDataBuffer = buffer.toString('base64');
     } catch {}
-    return { url: req.url(), method: req.method(), headers: req.headers(), postData: postData ?? null, postDataBuffer, resourceType: req.resourceType ? req.resourceType() : 'document' };
+    return { url: req.url(), method: req.method(), headers: req.headers(), postData: postData ?? null, postDataBuffer, resourceType: req.resourceType ? req.resourceType() : 'document', isNavigationRequest: req.isNavigationRequest ? req.isNavigationRequest() : false };
   }
 
   serializeResponse(response) {


### PR DESCRIPTION
`Request::isNavigationRequest()` always returns `false`. It reads `$this->data['isNavigationRequest'] ?? false`, but `serializeRequest()` in `bin/playwright-server.js` never includes the field, so the default is all any caller ever sees.

Added it to the payload alongside `resourceType`, using the same defensive `req.isNavigationRequest ? ... : false` shape as the neighbouring properties.

Verified against a route handler on a page with a subresource: the document request now reports `true` and a stylesheet request reports `false` (both reported `false` before).
