### PR TITLE
Resolve input file paths before sending

### DIFF
--- a/src/Locator/Locator.php
+++ b/src/Locator/Locator.php
@@ -385,15 +385,18 @@ final class Locator implements \Stringable, LocatorInterface
             'files' => $fileArray,
         ]);
 
+        $resolved = [];
         foreach ($fileArray as $file) {
-            if (!\file_exists($file)) {
+            $absolute = \realpath($file);
+            if (false === $absolute) {
                 $this->logger->error('File not found for input upload', ['file' => $file]);
                 throw new PlaywrightException(\sprintf('File not found: %s', $file));
             }
+            $resolved[] = $absolute;
         }
 
         try {
-            $this->sendCommand('locator.setInputFiles', ['files' => $fileArray, 'options' => $options->toArray()]);
+            $this->sendCommand('locator.setInputFiles', ['files' => $resolved, 'options' => $options->toArray()]);
             $this->logger->info('Successfully set input files on locator', [
                 'selector' => (string) $this->selectorChain,
                 'fileCount' => \count($fileArray),

--- a/tests/Integration/Input/FileUploadIntegrationTest.php
+++ b/tests/Integration/Input/FileUploadIntegrationTest.php
@@ -84,6 +84,24 @@ final class FileUploadIntegrationTest extends TestCase
     }
 
     #[Test]
+    public function itUploadsAFileGivenByARelativePath(): void
+    {
+        $cwd = (string) getcwd();
+        chdir(\dirname($this->tempFile));
+
+        try {
+            $this->page->locator('#file')->setInputFiles([basename($this->tempFile)]);
+            usleep(100000);
+
+            $name = $this->page->evaluate('() => document.body.dataset.filename');
+        } finally {
+            chdir($cwd);
+        }
+
+        $this->assertSame(basename($this->tempFile), $name);
+    }
+
+    #[Test]
     public function itUploadsAFileWithLocatorAndOptionsObject(): void
     {
         $this->page->locator('#file')->setInputFiles(

--- a/tests/Unit/Locator/LocatorSetInputFilesTest.php
+++ b/tests/Unit/Locator/LocatorSetInputFilesTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the community-maintained Playwright PHP project.
+ * It is not affiliated with or endorsed by Microsoft.
+ *
+ * (c) 2025-Present - Playwright PHP - https://github.com/playwright-php
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Playwright\Tests\Unit\Locator;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Playwright\Exception\PlaywrightException;
+use Playwright\Locator\Locator;
+use Playwright\Transport\TransportInterface;
+
+#[CoversClass(Locator::class)]
+final class LocatorSetInputFilesTest extends TestCase
+{
+    private string $originalCwd;
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        $this->originalCwd = (string) getcwd();
+        $this->tmpDir = sys_get_temp_dir().'/pw-input-files-'.bin2hex(random_bytes(6));
+        mkdir($this->tmpDir);
+        $this->tmpDir = (string) realpath($this->tmpDir);
+    }
+
+    protected function tearDown(): void
+    {
+        chdir($this->originalCwd);
+
+        foreach (glob($this->tmpDir.'/*') ?: [] as $file) {
+            unlink($file);
+        }
+        rmdir($this->tmpDir);
+    }
+
+    public function testRelativePathIsResolvedBeforeItReachesTheTransport(): void
+    {
+        file_put_contents($this->tmpDir.'/upload.txt', 'hello');
+        chdir($this->tmpDir);
+
+        $sent = null;
+        $transport = $this->createMock(TransportInterface::class);
+        $transport->method('send')->willReturnCallback(function (array $payload) use (&$sent): array {
+            $sent = $payload;
+
+            return [];
+        });
+
+        (new Locator($transport, 'page1', '#f'))->setInputFiles('upload.txt');
+
+        self::assertSame([$this->tmpDir.'/upload.txt'], $sent['files']);
+    }
+
+    public function testMissingFileIsRejectedBeforeAnythingIsSent(): void
+    {
+        $transport = $this->createMock(TransportInterface::class);
+        $transport->expects(self::never())->method('send');
+
+        $this->expectException(PlaywrightException::class);
+        $this->expectExceptionMessage('File not found: nope.txt');
+
+        (new Locator($transport, 'page1', '#f'))->setInputFiles('nope.txt');
+    }
+}


### PR DESCRIPTION
`setInputFiles()` checked the path with `file_exists()`, which resolves against the PHP working directory, then sent the unresolved string to the Node bridge, which resolves against its own. A relative path passed the check and then failed with ENOENT.

Paths are now resolved with `realpath()` before they are sent. `Page::setInputFiles()` delegates to the locator, so it is fixed too.

Reported downstream as playwright-php/playwright-mink#5.