### PR TITLE
Standardize on bin/.gitignore for bin/ artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,4 @@
 /.phpunit.cache/
-/bin/pnpm-lock.yaml
-/bin/package.lock
-/bin/yarn.lock
 /node_modules/
 /screenshots/
 /vendor/

--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -3,3 +3,5 @@ playwright-server.log
 screenshot_*
 pnpm-lock.yaml
 package-lock.json
+yarn.lock
+node_modules/


### PR DESCRIPTION
`bin/node_modules/` isn't ignored anywhere, so running `vendor/bin/playwright-install` leaves 18 MB of untracked files in a clone — the root rule is `/node_modules/`, anchored to the repo root by the leading slash.

Since `bin/.gitignore` already exists, this standardizes on it for everything under `bin/`: adds `node_modules/` and `yarn.lock`, drops `/bin/pnpm-lock.yaml`, `/bin/package.lock` and `/bin/yarn.lock` from the root file. That also drops a duplicate (`pnpm-lock.yaml` was in both) and a dead entry (nothing writes `package.lock`; npm writes `package-lock.json`, already covered).
