### PR TITLE
Add browser type and context browser

### DIFF
--- a/src/Browser/Browser.php
+++ b/src/Browser/Browser.php
@@ -36,8 +36,9 @@ final class Browser implements BrowserInterface
         private readonly string $defaultContextId,
         private readonly string $version,
         private readonly PlaywrightConfig $config,
+        private readonly BrowserType $browserType = BrowserType::CHROMIUM,
     ) {
-        $this->defaultContext = new BrowserContext($this->transport, $this->defaultContextId, $this->config);
+        $this->defaultContext = new BrowserContext($this->transport, $this->defaultContextId, $this->config, $this);
         $this->contexts[] = $this->defaultContext;
     }
 
@@ -61,7 +62,7 @@ final class Browser implements BrowserInterface
             throw new ProtocolErrorException('Invalid contextId returned from transport', 0);
         }
 
-        $context = new BrowserContext($this->transport, $response['contextId'], $this->config);
+        $context = new BrowserContext($this->transport, $response['contextId'], $this->config, $this);
         $this->contexts[] = $context;
 
         return $context;
@@ -85,6 +86,11 @@ final class Browser implements BrowserInterface
     public function contexts(): array
     {
         return $this->contexts;
+    }
+
+    public function browserType(): BrowserType
+    {
+        return $this->browserType;
     }
 
     public function isConnected(): bool

--- a/src/Browser/BrowserBuilder.php
+++ b/src/Browser/BrowserBuilder.php
@@ -135,7 +135,8 @@ final class BrowserBuilder
             $response['browserId'],
             $response['defaultContextId'],
             $response['version'],
-            $this->config
+            $this->config,
+            $this->toBrowserType()
         );
     }
 
@@ -181,7 +182,8 @@ final class BrowserBuilder
             $response['browserId'],
             $response['defaultContextId'],
             $response['version'],
-            $this->config
+            $this->config,
+            $this->toBrowserType()
         );
     }
 
@@ -227,7 +229,13 @@ final class BrowserBuilder
             $response['browserId'],
             $response['defaultContextId'],
             $response['version'],
-            $this->config
+            $this->config,
+            $this->toBrowserType()
         );
+    }
+
+    private function toBrowserType(): BrowserType
+    {
+        return BrowserType::tryFrom($this->browserType) ?? BrowserType::CHROMIUM;
     }
 }

--- a/src/Browser/BrowserContext.php
+++ b/src/Browser/BrowserContext.php
@@ -63,6 +63,7 @@ final class BrowserContext implements BrowserContextInterface, EventDispatcherIn
         private readonly TransportInterface $transport,
         private readonly string $contextId,
         private readonly PlaywrightConfig $config,
+        private readonly ?BrowserInterface $browser = null,
     ) {
         if (method_exists($this->transport, 'addEventDispatcher')) {
             $this->transport->addEventDispatcher($this->contextId, $this);
@@ -198,6 +199,11 @@ final class BrowserContext implements BrowserContextInterface, EventDispatcherIn
         $this->pages[$response['pageId']] = $page;
 
         return $page;
+    }
+
+    public function browser(): ?BrowserInterface
+    {
+        return $this->browser;
     }
 
     public function clipboardText(): string

--- a/src/Browser/BrowserContextInterface.php
+++ b/src/Browser/BrowserContextInterface.php
@@ -75,6 +75,14 @@ interface BrowserContextInterface
     public function pages(): array;
 
     /**
+     * The browser this context belongs to, or null for a persistent context.
+     *
+     * Contexts obtained from Browser::context() or Browser::newContext() always
+     * carry their browser.
+     */
+    public function browser(): ?BrowserInterface;
+
+    /**
      * Get storage state as array (legacy method).
      *
      * @return array<string, mixed>

--- a/src/Browser/BrowserInterface.php
+++ b/src/Browser/BrowserInterface.php
@@ -37,6 +37,11 @@ interface BrowserInterface
      */
     public function contexts(): array;
 
+    /**
+     * The browser engine this instance was launched with.
+     */
+    public function browserType(): BrowserType;
+
     public function isConnected(): bool;
 
     public function version(): string;

--- a/tests/Unit/Browser/BrowserBuilderTest.php
+++ b/tests/Unit/Browser/BrowserBuilderTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the community-maintained Playwright PHP project.
+ * It is not affiliated with or endorsed by Microsoft.
+ *
+ * (c) 2025-Present - Playwright PHP - https://github.com/playwright-php
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Playwright\Tests\Unit\Browser;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Playwright\Browser\BrowserBuilder;
+use Playwright\Browser\BrowserType;
+use Playwright\Configuration\PlaywrightConfig;
+use Playwright\Tests\Mocks\TestLogger;
+use Playwright\Transport\TransportInterface;
+
+#[CoversClass(BrowserBuilder::class)]
+final class BrowserBuilderTest extends TestCase
+{
+    private const WS_ENDPOINT = 'ws://127.0.0.1:9222/devtools';
+    private const CDP_ENDPOINT = 'http://127.0.0.1:9222/';
+
+    /**
+     * @return iterable<string, array{string, BrowserType}>
+     */
+    public static function browserNameProvider(): iterable
+    {
+        yield 'chromium' => ['chromium', BrowserType::CHROMIUM];
+        yield 'firefox' => ['firefox', BrowserType::FIREFOX];
+        yield 'webkit' => ['webkit', BrowserType::WEBKIT];
+    }
+
+    #[DataProvider('browserNameProvider')]
+    public function testLaunchCarriesTheBrowserNameToTheBrowser(string $name, BrowserType $expected): void
+    {
+        $this->assertSame($expected, $this->builder($name)->launch()->browserType());
+    }
+
+    #[DataProvider('browserNameProvider')]
+    public function testConnectCarriesTheBrowserNameToTheBrowser(string $name, BrowserType $expected): void
+    {
+        $this->assertSame($expected, $this->builder($name)->connect(self::WS_ENDPOINT)->browserType());
+    }
+
+    #[DataProvider('browserNameProvider')]
+    public function testConnectOverCdpCarriesTheBrowserNameToTheBrowser(string $name, BrowserType $expected): void
+    {
+        $this->assertSame($expected, $this->builder($name)->connectOverCDP(self::CDP_ENDPOINT)->browserType());
+    }
+
+    private function builder(string $browserType): BrowserBuilder
+    {
+        $transport = $this->createMock(TransportInterface::class);
+        $transport->method('send')->willReturn([
+            'browserId' => 'b1',
+            'defaultContextId' => 'ctx1',
+            'version' => '1.0',
+        ]);
+
+        return new BrowserBuilder($browserType, $transport, new TestLogger(), new PlaywrightConfig());
+    }
+}

--- a/tests/Unit/Browser/BrowserContextTest.php
+++ b/tests/Unit/Browser/BrowserContextTest.php
@@ -16,6 +16,7 @@ namespace Playwright\Tests\Unit\Browser;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Playwright\Browser\Browser;
 use Playwright\Browser\BrowserContext;
 use Playwright\Browser\StorageState;
 use Playwright\Configuration\PlaywrightConfig;
@@ -466,6 +467,40 @@ final class BrowserContextTest extends TestCase
             ]);
 
         $this->context->disableNetworkThrottling();
+    }
+
+    public function testAContextBuiltWithoutABrowserHasNone(): void
+    {
+        $this->assertNull($this->context->browser());
+    }
+
+    public function testTheDefaultContextPointsBackToItsBrowser(): void
+    {
+        $browser = $this->browser();
+
+        $this->assertSame($browser, $browser->context()->browser());
+    }
+
+    public function testAContextCreatedLaterPointsBackToItsBrowser(): void
+    {
+        $browser = $this->browser();
+
+        $this->assertSame($browser, $browser->newContext()->browser());
+    }
+
+    public function testEveryContextOfABrowserSharesTheSameBackReference(): void
+    {
+        $browser = $this->browser();
+
+        $this->assertSame($browser->newContext()->browser(), $browser->newContext()->browser());
+    }
+
+    private function browser(): Browser
+    {
+        $transport = $this->createMock(TransportInterface::class);
+        $transport->method('send')->willReturn(['contextId' => 'ctx_new']);
+
+        return new Browser($transport, 'b', 'ctx_default', '1.0', new PlaywrightConfig());
     }
 
     /**

--- a/tests/Unit/Browser/BrowserTest.php
+++ b/tests/Unit/Browser/BrowserTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the community-maintained Playwright PHP project.
+ * It is not affiliated with or endorsed by Microsoft.
+ *
+ * (c) 2025-Present - Playwright PHP - https://github.com/playwright-php
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Playwright\Tests\Unit\Browser;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Playwright\Browser\Browser;
+use Playwright\Browser\BrowserType;
+use Playwright\Configuration\PlaywrightConfig;
+use Playwright\Transport\TransportInterface;
+
+#[CoversClass(Browser::class)]
+final class BrowserTest extends TestCase
+{
+    public function testBrowserTypeReportsTheEngineItWasBuiltWith(): void
+    {
+        $browser = $this->browser(BrowserType::FIREFOX);
+
+        $this->assertSame(BrowserType::FIREFOX, $browser->browserType());
+    }
+
+    public function testBrowserTypeDefaultsToChromium(): void
+    {
+        $browser = new Browser($this->transport(), 'b', 'ctx_default', '1.0', new PlaywrightConfig());
+
+        $this->assertSame(BrowserType::CHROMIUM, $browser->browserType());
+    }
+
+    private function browser(BrowserType $type): Browser
+    {
+        return new Browser($this->transport(), 'b', 'ctx_default', '1.0', new PlaywrightConfig(), $type);
+    }
+
+    private function transport(): TransportInterface
+    {
+        $transport = $this->createMock(TransportInterface::class);
+        $transport->method('send')->willReturn(['contextId' => 'ctx_new']);
+
+        return $transport;
+    }
+}


### PR DESCRIPTION
This pull request introduces the concept of browser engine type tracking (`BrowserType`) throughout the browser and context lifecycle, ensuring that each `Browser` and its associated `BrowserContext`s know which engine (Chromium, Firefox, or WebKit) they are using. 

* Added a `BrowserType` parameter to the `Browser` constructor, defaulting to `CHROMIUM`, and stored it as a readonly property. The engine type is now passed from `BrowserBuilder` to `Browser` during instantiation
* Added the `browserType()` accessor to the `BrowserInterface` and implemented it in `Browser`, allowing consumers to query the engine type

These changes make it easier to reason about which browser engine is in use and maintain correct relationships between browsers and their contexts.