### PR TITLE
Name failure screenshots after the failing test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 - Targeted browser installation through `playwright-install [browser...]`
 
+### Fixed
+- Failure screenshots are named after the failing test again on PHPUnit 10 and newer
+
 ## [1.4.0] - 2026-08-10
 
 ### Added

--- a/src/Testing/PlaywrightTestCaseTrait.php
+++ b/src/Testing/PlaywrightTestCaseTrait.php
@@ -93,8 +93,7 @@ trait PlaywrightTestCaseTrait
         $status = $this->status();
 
         if ($status->isFailure() || $status->isError()) {
-            $testName = method_exists($this, 'getName') && is_string($this->getName()) ? $this->getName() : 'test';
-            $this->captureFailureArtifacts($testName);
+            $this->captureFailureArtifacts($this->resolveTestName());
         }
 
         $this->safeClose($this->context);
@@ -178,6 +177,31 @@ trait PlaywrightTestCaseTrait
         $value = is_string($env) ? $env : '';
 
         return '' !== $value && '0' !== $value;
+    }
+
+    private function resolveTestName(): string
+    {
+        foreach (['name', 'getName'] as $method) {
+            if (!method_exists($this, $method)) {
+                continue;
+            }
+
+            $name = $this->{$method}();
+
+            if (is_string($name) && '' !== $name) {
+                return self::sanitizeFileName($name);
+            }
+        }
+
+        return 'test';
+    }
+
+    private static function sanitizeFileName(string $name): string
+    {
+        $sanitized = preg_replace('/[^A-Za-z0-9._-]+/', '_', $name) ?? '';
+        $sanitized = trim($sanitized, '_.');
+
+        return '' === $sanitized ? 'test' : $sanitized;
     }
 
     private function captureFailureArtifacts(string $testName): void

--- a/tests/Unit/Testing/PlaywrightTestCaseTest.php
+++ b/tests/Unit/Testing/PlaywrightTestCaseTest.php
@@ -59,4 +59,30 @@ final class PlaywrightTestCaseTest extends TestCase
         $this->assertTrue($setUpMethod->hasReturnType());
         $this->assertEquals('void', $setUpMethod->getReturnType()->getName());
     }
+
+    public function testResolveTestNameUsesTheRunningTestName(): void
+    {
+        $case = new class('testExample') extends PlaywrightTestCase {
+            public function testExample(): void
+            {
+            }
+        };
+
+        $method = new \ReflectionMethod($case, 'resolveTestName');
+
+        $this->assertSame('testExample', $method->invoke($case));
+    }
+
+    public function testResolveTestNameStaysUsableAsAFileName(): void
+    {
+        $case = new class('testExample with data set "a/b"') extends PlaywrightTestCase {
+            public function testExample(): void
+            {
+            }
+        };
+
+        $method = new \ReflectionMethod($case, 'resolveTestName');
+
+        $this->assertSame('testExample_with_data_set_a_b', $method->invoke($case));
+    }
 }

--- a/tests/Unit/Testing/PlaywrightTestCaseTest.php
+++ b/tests/Unit/Testing/PlaywrightTestCaseTest.php
@@ -85,4 +85,17 @@ final class PlaywrightTestCaseTest extends TestCase
 
         $this->assertSame('testExample_with_data_set_a_b', $method->invoke($case));
     }
+
+    public function testResolveTestNameFallsBackWhenTheNameIsEmpty(): void
+    {
+        $case = new class('') extends PlaywrightTestCase {
+            public function testExample(): void
+            {
+            }
+        };
+
+        $method = new \ReflectionMethod($case, 'resolveTestName');
+
+        $this->assertSame('test', $method->invoke($case));
+    }
 }


### PR DESCRIPTION
PHPUnit 10 renamed getName() to name(), so the method_exists() check in tearDownPlaywright() always fell through to the 'test' default. With more than one failing test in a run, every screenshot overwrote the previous one and the evidence was gone by the time the run finished.

resolveTestName() asks name() first and falls back to getName(), so the trait keeps working on PHPUnit 9 as well. The name ends up in a file name and a data set turns it into something like `testFoo with data set "a/b"`, so it is sanitized before use.